### PR TITLE
[ADD] 헬스 체크 관련 속성 추가

### DIFF
--- a/IMJM-server/src/main/resources/application.properties
+++ b/IMJM-server/src/main/resources/application.properties
@@ -18,3 +18,12 @@ server.port=8080
 # ?? ??
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
+
+# \uAE30\uBCF8 \uD5EC\uC2A4 \uCCB4\uD06C \uC5D4\uB4DC\uD3EC\uC778\uD2B8 \uD65C\uC131\uD654
+management.endpoints.web.exposure.include=health,info
+
+# \uC0C1\uC138 \uD5EC\uC2A4 \uC815\uBCF4 \uD45C\uC2DC (\uC120\uD0DD\uC0AC\uD56D)
+management.endpoint.health.show-details=always
+
+# Redis \uD5EC\uC2A4 \uCCB4\uD06C\uB97C \uBB34\uC2DC\uD558\uACE0 \uB2E4\uB978 \uAD6C\uC131 \uC694\uC18C\uB9CC \uD655\uC778
+management.health.redis.enabled=false


### PR DESCRIPTION
## 작업 내용 및 기능 요약
헬스 체크 관련 속성 추가

기본 헬스 체크 엔드포인트 활성화
management.endpoints.web.exposure.include=health,info

상세 헬스 정보 표시 (선택사항)
management.endpoint.health.show-details=always

Redis 헬스 체크를 무시하고 다른 구성 요소만 확인
management.health.redis.enabled=false