### PR TITLE
[FEAT] header에 로그인 페이지 이동경로 추가

### DIFF
--- a/IMJM-client/src/App.tsx
+++ b/IMJM-client/src/App.tsx
@@ -4,6 +4,7 @@ import Footer from './components/layout/Footer';
 import Home from './pages/Home/Home';
 import SalonDetail from "./pages/HairSalon/SalonDetail";
 import HairSalon from "./pages/HairSalon/HairSalon";
+import Login from "./pages/User/Login"
 
 function App() {
     return (
@@ -18,6 +19,7 @@ function App() {
                         <Route path="/community" element={<div>Community Page (준비 중)</div>} />
                         <Route path="/myPage" element={<div>My Page (준비 중)</div>} />
                         <Route path="/salon/:id" element={<SalonDetail />} />
+                        <Route path="/login" element={<Login />} />
                     </Routes>
                 </main>
                 <Footer />

--- a/IMJM-client/src/components/layout/Header.css
+++ b/IMJM-client/src/components/layout/Header.css
@@ -67,3 +67,29 @@
 .MuiSelect-select {
     padding: 4px 12px !important;
 }
+
+.login-button {
+    background-color: #f39c91;
+    color: white;
+    border: none;
+    border-radius: 20px;
+    padding: 5px 10px;
+    font-size: 14px;
+    cursor: pointer;
+    height: 30px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-left: 10px;
+    transition: background-color 0.3s;
+}
+
+.login-button:hover {
+    background-color: #e57c70;
+}
+
+/* 필요한 경우 추가 스타일링 */
+.header-actions {
+    display: flex;
+    align-items: center;
+}

--- a/IMJM-client/src/components/layout/Header.tsx
+++ b/IMJM-client/src/components/layout/Header.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import './Header.css';
 import logo from '../../assets/images/logo.png';
 import MenuItem from '@mui/material/MenuItem';
@@ -11,10 +12,17 @@ import NotificationsIcon from '@mui/icons-material/Notifications';
 type Language = 'ko' | 'en';
 
 function Header(): React.ReactElement {
-    const [language, setLanguage] = useState<Language>('ko'); // 기본값을 한글(ko)로 설정
+    const [language, setLanguage] = useState<Language>('ko');
+    const [isLoggedIn] = useState<boolean>(false); // 로그인 상태 추적
+    const navigate = useNavigate();
 
     const handleLanguageChange = (event: SelectChangeEvent<Language>): void => {
         setLanguage(event.target.value as Language);
+    };
+
+    // 로그인 페이지로 이동
+    const navigateToLogin = (): void => {
+        navigate('/login');
     };
 
     return (
@@ -47,15 +55,26 @@ function Header(): React.ReactElement {
                     <MenuItem value={'ko'}>한국어</MenuItem>
                     <MenuItem value={'en'}>English</MenuItem>
                 </Select>
-                <div className="header-icons">
-                    <button className="icon-button">
-                        <ChatIcon />
+
+                {isLoggedIn ? (
+                    // 로그인되어 있을 때 채팅과 알림 아이콘 표시
+                    <div className="header-icons">
+                        <button className="icon-button">
+                            <ChatIcon />
+                        </button>
+                        <button className="icon-button">
+                            <NotificationsIcon />
+                            <span className="notification-badge">1</span>
+                        </button>
+                    </div>
+                ) : (
+                    <button
+                        className="login-button"
+                        onClick={navigateToLogin}
+                    >
+                        {language === 'ko' ? '로그인' : 'Login'}
                     </button>
-                    <button className="icon-button">
-                        <NotificationsIcon />
-                        <span className="notification-badge">1</span>
-                    </button>
-                </div>
+                )}
             </div>
         </header>
     );

--- a/IMJM-client/src/pages/User/Login.tsx
+++ b/IMJM-client/src/pages/User/Login.tsx
@@ -1,0 +1,10 @@
+
+const Login = () => {
+    return (
+        <div>
+<h1>로그인 페이지</h1>
+        </div>
+    );
+};
+
+export default Login;

--- a/IMJM-client/src/type/global.d.ts
+++ b/IMJM-client/src/type/global.d.ts
@@ -1,0 +1,38 @@
+// 이미지 파일 타입 선언
+declare module '*.png' {
+    const src: string;
+    export default src;
+}
+
+declare module '*.jpg' {
+    const src: string;
+    export default src;
+}
+
+declare module '*.jpeg' {
+    const src: string;
+    export default src;
+}
+
+declare module '*.gif' {
+    const src: string;
+    export default src;
+}
+
+declare module '*.svg' {
+    const src: string;
+    export default src;
+}
+
+// CSS 모듈 타입 선언 (CSS 모듈을 사용하는 경우)
+declare module '*.module.css' {
+    const classes: { [key: string]: string };
+    export default classes;
+}
+
+declare module '*.module.scss' {
+    const classes: { [key: string]: string };
+    export default classes;
+}
+
+// 기타 추가적인 글로벌 타입 선언들


### PR DESCRIPTION
## 작업 내용 및 기능 요약
header 부분 로그인 페이지 이동 버튼 추가

## 스크린샷
![image](https://github.com/user-attachments/assets/0406e6e7-2786-4be4-8135-133863b9dfd9)

## 관련 이슈
