### PR TITLE
[FEAT] 채팅 및 실시간 번역 구현

### DIFF
--- a/IMJM-server/build.gradle
+++ b/IMJM-server/build.gradle
@@ -61,6 +61,8 @@ dependencies {
 
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.flywaydb:flyway-database-postgresql'
+
+	implementation 'org.json:json:20231013'
 }
 
 tasks.named('test') {

--- a/IMJM-server/build.gradle
+++ b/IMJM-server/build.gradle
@@ -54,9 +54,12 @@ dependencies {
 
 	implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
 
-// AWS SDK (네이버 클라우드 Object Storage는 S3 호환)
+	// AWS SDK (네이버 클라우드 Object Storage는 S3 호환)
 	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.470'
 	implementation 'javax.annotation:javax.annotation-api:1.3.2'
+
+	implementation 'org.flywaydb:flyway-core'
+	implementation 'org.flywaydb:flyway-database-postgresql'
 }
 
 tasks.named('test') {

--- a/IMJM-server/build.gradle
+++ b/IMJM-server/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/IMJM-server/src/main/java/com/IMJM/chat/client/HyperClovaTranslationClient.java
+++ b/IMJM-server/src/main/java/com/IMJM/chat/client/HyperClovaTranslationClient.java
@@ -1,0 +1,142 @@
+package com.IMJM.chat.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.*;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class HyperClovaTranslationClient {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${hyperclovax.api.url}")
+    private String apiUrl;
+
+    @Value("${hyperclovax.api.key}")
+    private String apiKey;
+
+    /**
+     * 하이퍼클로바X API를 이용한 텍스트 번역
+     */
+    public String translate(String text, String sourceLanguage, String targetLanguage) {
+        try {
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.set("Authorization", "Bearer " + apiKey);
+            headers.set("X-NCP-CLOVASTUDIO-REQUEST-ID", UUID.randomUUID().toString().replace("-", ""));
+            headers.set("Accept", "text/event-stream");
+
+            Map<String, Object> systemPrompt = new HashMap<>();
+            systemPrompt.put("role", "system");
+            systemPrompt.put("content", "당신은 헤어스타일과 미용 분야에 특화된 전문 번역가입니다. 미용실과 다국적 고객 간의 원활한 소통을 돕는 양방향 번역 서비스를 제공합니다. \n\n"
+                    + "[번역 방향] " + sourceLanguage + "에서 " + targetLanguage + "로 번역해주세요.\n\n"
+                    + "[번역 임무] \n"
+                    + "1. 한국어 미용실 메시지를 다양한 외국어로 번역 (한국어 → 외국어) \n"
+                    + "2. 외국인 고객의 메시지를 한국어로 번역 (외국어 → 한국어) \n\n"
+                    + "[번역 가이드라인] \n"
+                    + "◆ 미용실 메시지 번역 (한국어 → 외국어): \n"
+                    + "- 한국 미용 용어와 표현을 외국인 고객이 이해하기 쉬운 표현으로 변환 \n"
+                    + "- 시술 과정, 가격, 예약 시간 등 중요 정보를 명확하게 전달 \n"
+                    + "- 한국적 서비스 문화(친절함, 존중)의 뉘앙스를 유지하여 번역 \n"
+                    + "- 외국인이 생소할 수 있는 한국 특유의 미용 개념은 간략한 설명 추가 \n\n"
+                    + "◆ 고객 메시지 번역 (외국어 → 한국어): \n"
+                    + "- 외국인 고객의 헤어스타일 요청을 한국 미용실이 이해하기 쉬운 전문 용어로 변환 \n"
+                    + "- 외국 헤어스타일 트렌드나 용어를 한국 미용업계에서 통용되는 표현으로 적절히 변환 \n"
+                    + "- 문화적 차이로 인한 오해가 생길 수 있는 표현을 자연스럽게 조정 \n"
+                    + "- 외국인 특유의 표현 방식을 한국 미용실 맥락에 맞게 조정하되 원래 의도 유지 \n\n"
+                    + "◆ 미용 전문 용어 정확한 변환: \n"
+                    + "1. 헤어스타일 용어: \n"
+                    + "- 한국어: 레이어드컷, 머쉬룸컷, 허쉬컷, 울프컷, 태슬컷, 히메컷 등 \n"
+                    + "- 영어: layered cut, mushroom cut, hush cut, wolf cut, tassel cut, hime cut 등 \n"
+                    + "2. 염색 용어: \n"
+                    + "- 한국어: 발레아쥬, 옴브레, 하이라이트, 로우라이트, 베이스, 탈색, 톤다운 등 \n"
+                    + "- 영어: balayage, ombre, highlights, lowlights, base color, bleaching, tone-down 등 \n"
+                    + "3. 펌 용어: \n"
+                    + "- 한국어: 볼륨펌, C컬, S컬, 디지털펌, 에어펌, 매직스트레이트, 셋팅펌 등 \n"
+                    + "- 영어: volume perm, C-curl, S-curl, digital perm, air perm, magic straight, setting perm 등 \n"
+                    + "4. 트리트먼트 용어: \n"
+                    + "- 한국어: 두피케어, 단백질 트리트먼트, 케라틴 트리트먼트, 모발 영양 공급 등 \n"
+                    + "- 영어: scalp care, protein treatment, keratin treatment, hair nourishment 등 \n\n"
+                    + "◆ 특수 상황 처리: \n"
+                    + "- 고객의 불만 사항은 부드럽게 유지하되 내용은 정확히 전달 \n"
+                    + "- 알레르기나 긴급 상황 관련 내용은 최우선으로 명확하게 번역 \n"
+                    + "- 애매한 표현은 가능한 옵션을 함께 제시하는 방식으로 번역 \n"
+                    + "- 이모티콘과 줄임말은 각 문화권에 맞게 자연스럽게 변환 \n\n"
+                    + "번역할 텍스트: \"" + text + "\"\n\n"
+                    + "위 텍스트를 " + sourceLanguage + "에서 " + targetLanguage + "로 번역하되, 미용실과 고객 간의 원활한 소통이 이루어질 수 있도록 전문성과 문화적 맥락을 모두 고려해 번역해주세요. 번역 결과만 제공해주세요.");
+
+            Map<String, Object> userPrompt = new HashMap<>();
+            userPrompt.put("role", "user");
+            userPrompt.put("content", text);
+
+            Map<String, Object> requestBody = new HashMap<>();
+            requestBody.put("messages", new Object[]{systemPrompt, userPrompt});
+
+            // 추가 파라미터
+            requestBody.put("topP", 0.8);
+            requestBody.put("topK", 0);
+            requestBody.put("temperature", 0.5);  // 번역에는 낮은 온도가 적합
+            requestBody.put("maxTokens", 2048);
+            requestBody.put("repeatPenalty", 1.1);
+            requestBody.put("stopBefore", new String[]{});
+            requestBody.put("includeAiFilters", false);
+            requestBody.put("seed", 0);
+
+            HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
+
+            // String으로 응답 받기
+            String response = restTemplate.postForObject(apiUrl, entity, String.class);
+
+            // SSE 형식의 응답 파싱
+            String translatedText = parseSSEResponse(response);
+            return translatedText;
+
+        } catch (Exception e) {
+            throw new RuntimeException("Translation error: " + e.getMessage(), e);
+        }
+    }
+
+    // SSE 응답 파싱 메소드 추가
+    private String parseSSEResponse(String sseResponse) {
+        if (sseResponse == null || sseResponse.isEmpty()) {
+            return "";
+        }
+
+        String[] lines = sseResponse.split("\n");
+        String finalMessage = "";
+        Set<String> uniqueContents = new HashSet<>();
+
+        for (String line : lines) {
+            if (line.startsWith("data:") && !line.contains("[DONE]")) {
+                try {
+                    String jsonData = line.substring(5).trim();
+                    ObjectMapper mapper = new ObjectMapper();
+                    JsonNode root = mapper.readTree(jsonData);
+
+                    if (root.has("message") && root.get("message").has("content")) {
+                        String content = root.get("message").get("content").asText();
+                        if (content != null && !content.isEmpty() && !uniqueContents.contains(content)) {
+                            finalMessage = content;
+                            uniqueContents.add(content);
+                        }
+                    }
+                } catch (Exception e) {
+                    log.error("Error parsing SSE response", e);
+                }
+            }
+        }
+
+        return finalMessage;
+    }
+}

--- a/IMJM-server/src/main/java/com/IMJM/chat/controller/ChatController.java
+++ b/IMJM-server/src/main/java/com/IMJM/chat/controller/ChatController.java
@@ -9,7 +9,9 @@ import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -49,9 +51,23 @@ public class ChatController {
     }
 
     // 메시지 읽음 처리
-    @PutMapping("/messages/read")
-    public ResponseEntity<Void> markMessagesAsRead(@RequestParam Long chatRoomId, @RequestParam String senderType) {
+    @PutMapping("/messages/read/{chatRoomId}")
+    public ResponseEntity<Map<String, Boolean>> markMessagesAsRead(
+            @PathVariable Long chatRoomId,
+            @RequestParam String senderType) {
         chatService.markMessagesAsRead(chatRoomId, senderType);
-        return ResponseEntity.ok().build();
+        Map<String, Boolean> response = new HashMap<>();
+        response.put("success", true);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/messages/unread/count/{chatRoomId}")
+    public ResponseEntity<Map<String, Integer>> getUnreadCount(
+            @PathVariable Long chatRoomId,
+            @RequestParam String senderType) {
+        int count = chatService.countUnreadMessages(chatRoomId, senderType);
+        Map<String, Integer> response = new HashMap<>();
+        response.put("count", count);
+        return ResponseEntity.ok(response);
     }
 }

--- a/IMJM-server/src/main/java/com/IMJM/chat/controller/ChatController.java
+++ b/IMJM-server/src/main/java/com/IMJM/chat/controller/ChatController.java
@@ -1,0 +1,57 @@
+package com.IMJM.chat.controller;
+
+import com.IMJM.chat.dto.ChatMessageDto;
+import com.IMJM.chat.dto.ChatRoomDto;
+import com.IMJM.chat.service.ChatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chat")
+public class ChatController {
+
+    private final ChatService chatService;
+
+    // 웹소켓으로 메시지 전송
+    @MessageMapping("/chat.sendMessage")
+    public void sendMessage(@Payload ChatMessageDto chatMessageDto) {
+        chatService.sendMessage(chatMessageDto);
+    }
+
+    // 채팅방 목록 조회 (사용자)
+    @GetMapping("/rooms/user/{userId}")
+    public ResponseEntity<List<ChatRoomDto>> getUserChatRooms(@PathVariable String userId) {
+        return ResponseEntity.ok(chatService.getUserChatRooms(userId));
+    }
+
+    // 채팅방 목록 조회 (미용실)
+    @GetMapping("/rooms/salon/{salonId}")
+    public ResponseEntity<List<ChatRoomDto>> getSalonChatRooms(@PathVariable String salonId) {
+        return ResponseEntity.ok(chatService.getSalonChatRooms(salonId));
+    }
+
+    // 채팅방 생성 또는 조회
+    @PostMapping("/room")
+    public ResponseEntity<ChatRoomDto> createChatRoom(@RequestParam String userId, @RequestParam String salonId) {
+        return ResponseEntity.ok(chatService.getChatRoom(userId, salonId));
+    }
+
+    // 채팅방 메시지 목록 조회
+    @GetMapping("/messages/{chatRoomId}")
+    public ResponseEntity<List<ChatMessageDto>> getChatMessages(@PathVariable Long chatRoomId) {
+        return ResponseEntity.ok(chatService.getChatMessages(chatRoomId));
+    }
+
+    // 메시지 읽음 처리
+    @PutMapping("/messages/read")
+    public ResponseEntity<Void> markMessagesAsRead(@RequestParam Long chatRoomId, @RequestParam String senderType) {
+        chatService.markMessagesAsRead(chatRoomId, senderType);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/IMJM-server/src/main/java/com/IMJM/chat/controller/TestTranslationController.java
+++ b/IMJM-server/src/main/java/com/IMJM/chat/controller/TestTranslationController.java
@@ -1,0 +1,36 @@
+package com.IMJM.chat.controller;
+
+import com.IMJM.chat.service.TranslationService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/test")
+public class TestTranslationController {
+
+    private final TranslationService translationService;
+
+    public TestTranslationController(TranslationService translationService) {
+        this.translationService = translationService;
+    }
+
+    @GetMapping("/translate")
+    public Map<String, String> testTranslate(
+            @RequestParam String text,
+            @RequestParam String source,
+            @RequestParam String target) {
+
+        String translated = translationService.translate(text, source, target);
+
+        Map<String, String> result = new HashMap<>();
+        result.put("original", text);
+        result.put("translated", translated);
+
+        return result;
+    }
+}

--- a/IMJM-server/src/main/java/com/IMJM/chat/dto/ChatMessageDto.java
+++ b/IMJM-server/src/main/java/com/IMJM/chat/dto/ChatMessageDto.java
@@ -1,0 +1,25 @@
+package com.IMJM.chat.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatMessageDto {
+
+    private Long id;
+    private Long chatRoomId;
+    private String senderType;  // 'USER' 또는 'SALON'
+    private String senderId;    // 사용자 ID 또는 샵 ID
+    private String message;
+    private Boolean isRead;
+    private LocalDateTime sentAt;
+    private String translatedMessage;
+    private String translationStatus;
+    private List<ChatPhotoDto> photos;
+}

--- a/IMJM-server/src/main/java/com/IMJM/chat/dto/ChatPhotoDto.java
+++ b/IMJM-server/src/main/java/com/IMJM/chat/dto/ChatPhotoDto.java
@@ -1,0 +1,13 @@
+package com.IMJM.chat.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatPhotoDto {
+    private Long photoId;
+    private String photoUrl;
+}

--- a/IMJM-server/src/main/java/com/IMJM/chat/dto/ChatRoomDto.java
+++ b/IMJM-server/src/main/java/com/IMJM/chat/dto/ChatRoomDto.java
@@ -1,0 +1,25 @@
+package com.IMJM.chat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatRoomDto {
+
+    private Long id;
+    private String userId;
+    private String salonId;
+    private String salonName;  // 미용실 이름 (표시용)
+    private String userName;   // 사용자 이름 (표시용)
+    private LocalDateTime createdAt;
+    private LocalDateTime lastMessageTime;
+    private String lastMessage;
+    private boolean hasUnreadMessages;
+}

--- a/IMJM-server/src/main/java/com/IMJM/chat/dto/ChatRoomDto.java
+++ b/IMJM-server/src/main/java/com/IMJM/chat/dto/ChatRoomDto.java
@@ -22,4 +22,6 @@ public class ChatRoomDto {
     private LocalDateTime lastMessageTime;
     private String lastMessage;
     private boolean hasUnreadMessages;
+
+    private int unreadCount;
 }

--- a/IMJM-server/src/main/java/com/IMJM/chat/exception/TranslationException.java
+++ b/IMJM-server/src/main/java/com/IMJM/chat/exception/TranslationException.java
@@ -1,0 +1,28 @@
+package com.IMJM.chat.exception;
+
+public class TranslationException extends RuntimeException {
+
+    private final String sourceLanguage;
+    private final String targetLanguage;
+    private final String originalMessage;
+
+    public TranslationException(String message, String sourceLanguage, String targetLanguage,
+                                String originalMessage, Throwable cause) {
+        super(message, cause);
+        this.sourceLanguage = sourceLanguage;
+        this.targetLanguage = targetLanguage;
+        this.originalMessage = originalMessage;
+    }
+
+    public String getSourceLanguage() {
+        return sourceLanguage;
+    }
+
+    public String getTargetLanguage() {
+        return targetLanguage;
+    }
+
+    public String getOriginalMessage() {
+        return originalMessage;
+    }
+}

--- a/IMJM-server/src/main/java/com/IMJM/chat/repository/ChatMessageRepository.java
+++ b/IMJM-server/src/main/java/com/IMJM/chat/repository/ChatMessageRepository.java
@@ -4,15 +4,23 @@ import com.IMJM.common.entity.ChatMessage;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ChatMessageRepository  extends JpaRepository<ChatMessage, Long> {
+
     List<ChatMessage> findByChatRoomIdOrderBySentAtAsc(Long chatRoomId);
 
     @Modifying
     @Query("UPDATE ChatMessage c SET c.isRead = true WHERE c.chatRoom.id = :chatRoomId AND c.senderType = :senderType AND c.isRead = false")
     void updateMessagesAsRead(Long chatRoomId, String senderType);
+
+    @Query("SELECT COUNT(cm) FROM ChatMessage cm WHERE cm.chatRoom.id = :chatRoomId AND cm.senderType = :senderType AND cm.isRead = false")
+    int countByReadFalseAndSenderType(@Param("chatRoomId") Long chatRoomId, @Param("senderType") String senderType);
+
+    Optional<ChatMessage> findTopByChatRoomIdOrderBySentAtDesc(Long chatRoomId);
 }

--- a/IMJM-server/src/main/java/com/IMJM/chat/repository/ChatMessageRepository.java
+++ b/IMJM-server/src/main/java/com/IMJM/chat/repository/ChatMessageRepository.java
@@ -23,4 +23,7 @@ public interface ChatMessageRepository  extends JpaRepository<ChatMessage, Long>
     int countByReadFalseAndSenderType(@Param("chatRoomId") Long chatRoomId, @Param("senderType") String senderType);
 
     Optional<ChatMessage> findTopByChatRoomIdOrderBySentAtDesc(Long chatRoomId);
+
+    @Query("SELECT cm FROM ChatMessage cm LEFT JOIN FETCH cm.chatRoom WHERE cm.chatRoom.id = :chatRoomId ORDER BY cm.sentAt ASC")
+    List<ChatMessage> findByChatRoomIdWithChatRoomOrderBySentAtAsc(@Param("chatRoomId") Long chatRoomId);
 }

--- a/IMJM-server/src/main/java/com/IMJM/chat/repository/ChatMessageRepository.java
+++ b/IMJM-server/src/main/java/com/IMJM/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,18 @@
+package com.IMJM.chat.repository;
+
+import com.IMJM.common.entity.ChatMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ChatMessageRepository  extends JpaRepository<ChatMessage, Long> {
+    List<ChatMessage> findByChatRoomIdOrderBySentAtAsc(Long chatRoomId);
+
+    @Modifying
+    @Query("UPDATE ChatMessage c SET c.isRead = true WHERE c.chatRoom.id = :chatRoomId AND c.senderType = :senderType AND c.isRead = false")
+    void updateMessagesAsRead(Long chatRoomId, String senderType);
+}

--- a/IMJM-server/src/main/java/com/IMJM/chat/repository/ChatPhotosRepository.java
+++ b/IMJM-server/src/main/java/com/IMJM/chat/repository/ChatPhotosRepository.java
@@ -1,0 +1,10 @@
+package com.IMJM.chat.repository;
+
+import com.IMJM.common.entity.ChatPhotos;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ChatPhotosRepository extends JpaRepository<ChatPhotos, Long> {
+    List<ChatPhotos> findByChatMessageId(Long chatMessageId);
+}

--- a/IMJM-server/src/main/java/com/IMJM/chat/repository/ChatPhotosRepository.java
+++ b/IMJM-server/src/main/java/com/IMJM/chat/repository/ChatPhotosRepository.java
@@ -6,5 +6,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface ChatPhotosRepository extends JpaRepository<ChatPhotos, Long> {
+
     List<ChatPhotos> findByChatMessageId(Long chatMessageId);
+
+    List<ChatPhotos> findByChatMessageIdIn(List<Long> chatMessageIds);
 }

--- a/IMJM-server/src/main/java/com/IMJM/chat/repository/ChatRoomRepository.java
+++ b/IMJM-server/src/main/java/com/IMJM/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,15 @@
+package com.IMJM.chat.repository;
+
+import com.IMJM.common.entity.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ChatRoomRepository  extends JpaRepository<ChatRoom, Long> {
+    Optional<ChatRoom> findByUserIdAndSalonId(String userId, String salonId);
+    List<ChatRoom> findByUserIdOrderByLastMessageTimeDesc(String userId);
+    List<ChatRoom> findBySalonIdOrderByLastMessageTimeDesc(String salonId);
+}

--- a/IMJM-server/src/main/java/com/IMJM/chat/repository/ChatSalonRepository.java
+++ b/IMJM-server/src/main/java/com/IMJM/chat/repository/ChatSalonRepository.java
@@ -1,0 +1,9 @@
+package com.IMJM.chat.repository;
+
+import com.IMJM.common.entity.Salon;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatSalonRepository extends JpaRepository<Salon, String> {
+}

--- a/IMJM-server/src/main/java/com/IMJM/chat/repository/ChatUserRepository.java
+++ b/IMJM-server/src/main/java/com/IMJM/chat/repository/ChatUserRepository.java
@@ -1,0 +1,9 @@
+package com.IMJM.chat.repository;
+
+import com.IMJM.common.entity.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatUserRepository extends JpaRepository<Users, String> {
+}

--- a/IMJM-server/src/main/java/com/IMJM/chat/service/ChatService.java
+++ b/IMJM-server/src/main/java/com/IMJM/chat/service/ChatService.java
@@ -1,0 +1,208 @@
+package com.IMJM.chat.service;
+
+import com.IMJM.chat.dto.ChatMessageDto;
+import com.IMJM.chat.dto.ChatPhotoDto;
+import com.IMJM.chat.dto.ChatRoomDto;
+import com.IMJM.chat.repository.*;
+import com.IMJM.common.entity.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatPhotosRepository chatPhotosRepository;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    private final ChatUserRepository chatUserRepository;
+    private final ChatSalonRepository chatSalonRepository;
+
+    // 채팅방 생성 또는 조회
+    @Transactional
+    public ChatRoomDto getChatRoom(String userId, String salonId) {
+        // 채팅방이 있는지 확인, 없으면 생성
+        ChatRoom chatRoom = chatRoomRepository.findByUserIdAndSalonId(userId, salonId)
+                .orElseGet(() -> {
+                    // 실제 유저와 샵 엔티티 조회
+                    Users user = chatUserRepository.findById(userId)
+                            .orElseThrow(() -> new RuntimeException("User not found with id: " + userId));
+
+                    Salon salon = chatSalonRepository.findById(salonId)
+                            .orElseThrow(() -> new RuntimeException("Salon not found with id: " + salonId));
+
+                    return chatRoomRepository.save(
+                            ChatRoom.builder()
+                                    .user(user)
+                                    .salon(salon)
+                                    .createdAt(LocalDateTime.now())
+                                    .lastMessageTime(LocalDateTime.now())
+                                    .build()
+                    );
+                });
+
+        return convertToChatRoomDto(chatRoom);
+    }
+
+    // 채팅방 목록 조회 (사용자용)
+    @Transactional(readOnly = true)
+    public List<ChatRoomDto> getUserChatRooms(String userId) {
+        return chatRoomRepository.findByUserIdOrderByLastMessageTimeDesc(userId).stream()
+                .map(this::convertToChatRoomDto)
+                .collect(Collectors.toList());
+    }
+
+    // 채팅방 목록 조회 (미용실용)
+    @Transactional(readOnly = true)
+    public List<ChatRoomDto> getSalonChatRooms(String salonId) {
+        return chatRoomRepository.findBySalonIdOrderByLastMessageTimeDesc(salonId).stream()
+                .map(this::convertToChatRoomDto)
+                .collect(Collectors.toList());
+    }
+
+    // 메시지 저장 및 전송
+    @Transactional
+    public ChatMessageDto sendMessage(ChatMessageDto messageDto) {
+        // 채팅방 조회
+        ChatRoom chatRoom = chatRoomRepository.findById(messageDto.getChatRoomId())
+                .orElseThrow(() -> new RuntimeException("Chat room not found"));
+
+        // 메시지 저장
+        ChatMessage chatMessage = ChatMessage.builder()
+                .chatRoom(chatRoom)
+                .senderType(messageDto.getSenderType())
+                .message(messageDto.getMessage())
+                .isRead(false)
+                .sentAt(LocalDateTime.now())
+                .translationStatus("none")
+                .build();
+
+        ChatMessage savedMessage = chatMessageRepository.save(chatMessage);
+
+        // 채팅방 마지막 메시지 시간 업데이트 (새 객체 생성)
+        ChatRoom updatedChatRoom = ChatRoom.builder()
+                .id(chatRoom.getId())
+                .user(chatRoom.getUser())
+                .salon(chatRoom.getSalon())
+                .createdAt(chatRoom.getCreatedAt())
+                .lastMessageTime(LocalDateTime.now())
+                .build();
+
+        chatRoomRepository.save(updatedChatRoom);
+
+        // 사진이 있는 경우 처리
+        List<ChatPhotoDto> savedPhotos = new ArrayList<>();
+        if (messageDto.getPhotos() != null && !messageDto.getPhotos().isEmpty()) {
+            for (ChatPhotoDto photoDto : messageDto.getPhotos()) {
+                ChatPhotos photo = ChatPhotos.builder()
+                        .chatMessage(savedMessage)
+                        .photoUrl(photoDto.getPhotoUrl())
+                        .uploadDate(LocalDateTime.now())
+                        .build();
+
+                ChatPhotos savedPhoto = chatPhotosRepository.save(photo);
+                savedPhotos.add(ChatPhotoDto.builder()
+                        .photoId(savedPhoto.getPhotoId())
+                        .photoUrl(savedPhoto.getPhotoUrl())
+                        .build());
+            }
+        }
+
+        // 응답 DTO 생성
+        ChatMessageDto responseDto = ChatMessageDto.builder()
+                .id(savedMessage.getId())
+                .chatRoomId(chatRoom.getId())
+                .senderType(savedMessage.getSenderType())
+                .message(savedMessage.getMessage())
+                .isRead(savedMessage.getIsRead())
+                .sentAt(savedMessage.getSentAt())
+                .translatedMessage(savedMessage.getTranslatedMessage())
+                .translationStatus(savedMessage.getTranslationStatus())
+                .photos(savedPhotos)
+                .build();
+
+        // 웹소켓으로 메시지 전송
+        // 사용자에게 전송
+        messagingTemplate.convertAndSendToUser(
+                chatRoom.getUser().getId(),
+                "/queue/messages",
+                responseDto
+        );
+
+        // 미용실에게 전송
+        messagingTemplate.convertAndSendToUser(
+                chatRoom.getSalon().getId(),
+                "/queue/messages",
+                responseDto
+        );
+
+        return responseDto;
+    }
+
+    // 메시지 목록 조회
+    @Transactional(readOnly = true)
+    public List<ChatMessageDto> getChatMessages(Long chatRoomId) {
+        List<ChatMessage> messages = chatMessageRepository.findByChatRoomIdOrderBySentAtAsc(chatRoomId);
+        return messages.stream()
+                .map(this::convertToChatMessageDto)
+                .collect(Collectors.toList());
+    }
+
+    // 메시지를 읽음으로 표시
+    @Transactional
+    public void markMessagesAsRead(Long chatRoomId, String senderType) {
+        String oppositeType = "USER".equals(senderType) ? "SALON" : "USER";
+        chatMessageRepository.updateMessagesAsRead(chatRoomId, oppositeType);
+    }
+
+    // 엔티티를 DTO로 변환하는 메서드들
+    private ChatRoomDto convertToChatRoomDto(ChatRoom chatRoom) {
+        String lastMessage = "";
+        boolean hasUnreadMessages = false;
+
+        // 마지막 메시지와 읽지 않은 메시지 확인은 실제 구현에서 추가
+
+        return ChatRoomDto.builder()
+                .id(chatRoom.getId())
+                .userId(chatRoom.getUser().getId())
+                .salonId(chatRoom.getSalon().getId())
+                .salonName(chatRoom.getSalon().getName()) // 실제로는 가져와야 함
+                .userName(chatRoom.getUser().getNickname()) // 실제로는 가져와야 함
+                .createdAt(chatRoom.getCreatedAt())
+                .lastMessageTime(chatRoom.getLastMessageTime())
+                .lastMessage(lastMessage)
+                .hasUnreadMessages(hasUnreadMessages)
+                .build();
+    }
+
+    private ChatMessageDto convertToChatMessageDto(ChatMessage message) {
+        // 사진 정보 로드
+        List<ChatPhotoDto> photos = chatPhotosRepository.findByChatMessageId(message.getId()).stream()
+                .map(photo -> ChatPhotoDto.builder()
+                        .photoId(photo.getPhotoId())
+                        .photoUrl(photo.getPhotoUrl())
+                        .build())
+                .collect(Collectors.toList());
+
+        return ChatMessageDto.builder()
+                .id(message.getId())
+                .chatRoomId(message.getChatRoom().getId())
+                .senderType(message.getSenderType())
+                .message(message.getMessage())
+                .isRead(message.getIsRead())
+                .sentAt(message.getSentAt())
+                .translatedMessage(message.getTranslatedMessage())
+                .translationStatus(message.getTranslationStatus())
+                .photos(photos)
+                .build();
+    }
+}

--- a/IMJM-server/src/main/java/com/IMJM/chat/service/HyperClovaXTranslationService.java
+++ b/IMJM-server/src/main/java/com/IMJM/chat/service/HyperClovaXTranslationService.java
@@ -1,6 +1,7 @@
 package com.IMJM.chat.service;
 
 import com.IMJM.chat.client.HyperClovaTranslationClient;
+import com.IMJM.chat.exception.TranslationException;
 import com.IMJM.chat.service.TranslationService;
 import lombok.RequiredArgsConstructor;
 import org.json.JSONArray;
@@ -19,22 +20,35 @@ public class HyperClovaXTranslationService implements TranslationService {
     private final HyperClovaTranslationClient hyperClovaClient;
 
     @Override
-    public String translate(String text, String sourceLanguage, String targetLanguage) {
+    public String translate(String text, String sourceLanguage, String targetLanguage) throws TranslationException {
         // 언어 코드 변환 (필요한 경우)
         String sourceLang = convertLanguageCode(sourceLanguage);
         String targetLang = convertLanguageCode(targetLanguage);
 
-        System.out.println("번역 요청 정보:");
-        System.out.println("원본 텍스트: " + text);
-        System.out.println("원본 언어: " + sourceLanguage + " (변환: " + sourceLang + ")");
-        System.out.println("대상 언어: " + targetLanguage + " (변환: " + targetLang + ")");
+        try {
+            // 클라이언트를 사용하여 번역 수행
+            String translatedText = hyperClovaClient.translate(text, sourceLang, targetLang);
 
-        // 클라이언트를 사용하여 번역 수행
-        String translatedText = hyperClovaClient.translate(text, sourceLang, targetLang);
+            if (translatedText == null || translatedText.isEmpty()) {
+                throw new TranslationException(
+                        "Empty translation result",
+                        sourceLanguage,
+                        targetLanguage,
+                        text,
+                        new IllegalStateException("Translation result is empty")
+                );
+            }
 
-        System.out.println("번역 결과: " + translatedText);
-
-        return translatedText;
+            return translatedText;
+        } catch (Exception e) {
+            throw new TranslationException(
+                    "Failed to translate text: " + e.getMessage(),
+                    sourceLanguage,
+                    targetLanguage,
+                    text,
+                    e
+            );
+        }
     }
 
     // 언어 코드 변환 (예: "ko" -> "한국어")

--- a/IMJM-server/src/main/java/com/IMJM/chat/service/HyperClovaXTranslationService.java
+++ b/IMJM-server/src/main/java/com/IMJM/chat/service/HyperClovaXTranslationService.java
@@ -1,0 +1,59 @@
+package com.IMJM.chat.service;
+
+import com.IMJM.chat.client.HyperClovaTranslationClient;
+import com.IMJM.chat.service.TranslationService;
+import lombok.RequiredArgsConstructor;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class HyperClovaXTranslationService implements TranslationService {
+
+    private final HyperClovaTranslationClient hyperClovaClient;
+
+    @Override
+    public String translate(String text, String sourceLanguage, String targetLanguage) {
+        // 언어 코드 변환 (필요한 경우)
+        String sourceLang = convertLanguageCode(sourceLanguage);
+        String targetLang = convertLanguageCode(targetLanguage);
+
+        System.out.println("번역 요청 정보:");
+        System.out.println("원본 텍스트: " + text);
+        System.out.println("원본 언어: " + sourceLanguage + " (변환: " + sourceLang + ")");
+        System.out.println("대상 언어: " + targetLanguage + " (변환: " + targetLang + ")");
+
+        // 클라이언트를 사용하여 번역 수행
+        String translatedText = hyperClovaClient.translate(text, sourceLang, targetLang);
+
+        System.out.println("번역 결과: " + translatedText);
+
+        return translatedText;
+    }
+
+    // 언어 코드 변환 (예: "ko" -> "한국어")
+    private String convertLanguageCode(String code) {
+        switch (code.toLowerCase()) {
+            case "ko": return "ko";
+            case "en": return "en";
+            case "ja": return "ja";
+            case "zh-cn": return "zh-CN";
+            case "zh-tw": return "zh-TW";
+            case "vi": return "vi";
+            case "th": return "th";
+            case "id": return "id";
+            case "fr": return "fr";
+            case "es": return "es";
+            case "ru": return "ru";
+            case "de": return "de";
+            case "it": return "it";
+            default: return code;
+        }
+    }
+}

--- a/IMJM-server/src/main/java/com/IMJM/chat/service/TranslationService.java
+++ b/IMJM-server/src/main/java/com/IMJM/chat/service/TranslationService.java
@@ -1,8 +1,10 @@
 package com.IMJM.chat.service;
 
+import com.IMJM.chat.exception.TranslationException;
+
 public interface TranslationService {
     /**
      * 텍스트를 소스 언어에서 타겟 언어로 번역합니다.
      */
-    String translate(String text, String sourceLanguage, String targetLanguage);
+    String translate(String text, String sourceLanguage, String targetLanguage) throws TranslationException;
 }

--- a/IMJM-server/src/main/java/com/IMJM/chat/service/TranslationService.java
+++ b/IMJM-server/src/main/java/com/IMJM/chat/service/TranslationService.java
@@ -1,0 +1,8 @@
+package com.IMJM.chat.service;
+
+public interface TranslationService {
+    /**
+     * 텍스트를 소스 언어에서 타겟 언어로 번역합니다.
+     */
+    String translate(String text, String sourceLanguage, String targetLanguage);
+}

--- a/IMJM-server/src/main/java/com/IMJM/common/entity/ChatMessage.java
+++ b/IMJM-server/src/main/java/com/IMJM/common/entity/ChatMessage.java
@@ -37,4 +37,13 @@ public class ChatMessage {
 
     @Column(name = "translation_status", length = 10)
     private String translationStatus = "none";
+
+    public void markAsRead() {
+        this.isRead = true;
+    }
+
+    public void updateTranslation(String translatedMessage, String status) {
+        this.translatedMessage = translatedMessage;
+        this.translationStatus = status;
+    }
 }

--- a/IMJM-server/src/main/java/com/IMJM/common/entity/ChatPhotos.java
+++ b/IMJM-server/src/main/java/com/IMJM/common/entity/ChatPhotos.java
@@ -1,0 +1,30 @@
+package com.IMJM.common.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "chat_photos")
+public class ChatPhotos {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "photo_id")
+    private Long photoId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_message_id", nullable = false)
+    private ChatMessage chatMessage;
+
+    @Column(name = "photo_url", length = 255, nullable = false)
+    private String photoUrl;
+
+    @Column(name = "upload_date")
+    private LocalDateTime uploadDate;
+}

--- a/IMJM-server/src/main/java/com/IMJM/common/entity/ChatRoom.java
+++ b/IMJM-server/src/main/java/com/IMJM/common/entity/ChatRoom.java
@@ -31,4 +31,8 @@ public class ChatRoom {
 
     @Column(name = "last_message_time", nullable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private LocalDateTime lastMessageTime;
+
+    public void updateLastMessageTime(LocalDateTime time) {
+        this.lastMessageTime = time;
+    }
 }

--- a/IMJM-server/src/main/java/com/IMJM/config/RestTemplateConfig.java
+++ b/IMJM-server/src/main/java/com/IMJM/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.IMJM.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/IMJM-server/src/main/java/com/IMJM/config/WebSocketConfig.java
+++ b/IMJM-server/src/main/java/com/IMJM/config/WebSocketConfig.java
@@ -1,0 +1,31 @@
+package com.IMJM.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        // 메시지 브로커 설정
+        // 클라이언트가 구독할 수 있는 주제 prefix
+        registry.enableSimpleBroker("/topic", "/queue");
+        // 메시지 송신 주소 prefix
+        registry.setApplicationDestinationPrefixes("/app");
+        // 유저별 구독을 위한 prefix
+        registry.setUserDestinationPrefix("/user");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        // 웹소켓 연결 엔드포인트 등록
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*")  // CORS 설정
+                .withSockJS();  // SockJS 지원 활성화
+    }
+}

--- a/IMJM-server/src/main/resources/application.properties
+++ b/IMJM-server/src/main/resources/application.properties
@@ -59,3 +59,7 @@ spring.flyway.schemas=imjm
 spring.flyway.default-schema=imjm
 spring.flyway.baseline-version=0
 spring.flyway.validate-on-migrate=true
+
+# Hyper Clova X
+hyperclovax.api.url=ENC(fD8d0nPxCKGCLr/Nhl/B28qoSCjUo2jR+aEtSBtehckrZiugcyLhe98JVCU+X1WiIz1SP//Am4y5IkO5PFdcZuf6Fn4Y5tWHTh4gQ4AwOm1RcqpSRcF7vg==)
+hyperclovax.api.key=ENC(9kWWqdu8IfPdUPglFq2pdTjd6FBYHcObwkSP/2GWe1V85H4v9E4tmcBiiHjt5vr/)

--- a/IMJM-server/src/main/resources/application.properties
+++ b/IMJM-server/src/main/resources/application.properties
@@ -4,40 +4,37 @@ spring.application.name=IMJM
 jasypt.encryptor.bean=jasyptEncryptor
 jasypt.encryptor.password=${JASYPT_KEY}
 
-# ?????? ?? ??
-#spring.datasource.url=ENC(o1RxpOGdpZ8thIHkM/GcmQZadigE8GB8W9QDAbSJOjPeJ1Jdvpvp1pWUlsEyc50dKmlelzZ1JKbHJkI++39TOc5vNwl2zrwW)
-spring.datasource.url=ENC(LGV0K9rkhFhWHt6RCT7HIf7omey5NUk5HODVoKFADboeQCIjchAo8mYwPoQknkfU)
+spring.datasource.url=ENC(o1RxpOGdpZ8thIHkM/GcmQZadigE8GB8W9QDAbSJOjPeJ1Jdvpvp1pWUlsEyc50dKmlelzZ1JKbHJkI++39TOc5vNwl2zrwW)
+#spring.datasource.url=ENC(LGV0K9rkhFhWHt6RCT7HIf7omey5NUk5HODVoKFADboeQCIjchAo8mYwPoQknkfU)
 spring.datasource.username=ENC(gDZE9xFux3ydtmDV9x6F9Q==)
 spring.datasource.password=ENC(qANakfdSDvAT7PxI8RUwQJfICd3rXNlw)
 spring.datasource.driver-class-name=org.postgresql.Driver
 
-# JPA ??
+# JPA
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 
-# ?? ?? ??
 server.port=8080
 
-# ?? ??
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
 
-# 모든 액추에이터 엔드포인트 노출
+# \uBAA8\uB4E0 \uC561\uCD94\uC5D0\uC774\uD130 \uC5D4\uB4DC\uD3EC\uC778\uD2B8 \uB178\uCD9C
 management.endpoints.web.exposure.include=*
 
-# 상세 정보 표시
+# \uC0C1\uC138 \uC815\uBCF4 \uD45C\uC2DC
 management.endpoint.health.show-details=always
 
-# 보안 비활성화 (개발/테스트 환경)
+# \uBCF4\uC548 \uBE44\uD65C\uC131\uD654 (\uAC1C\uBC1C/\uD14C\uC2A4\uD2B8 \uD658\uACBD)
 management.endpoints.web.exposure.exclude=
 
 # jwt
 jwt.secret.key=ENC(P5VtdDcx3wZP132xwQgfW2v4vht3Bn7SfrCKxw6mJ7jkIsTcBUN3NZkzT5eKPoqqSQgqRP6yyKM=)
 
 # google
-#registration
+# registration
 spring.security.oauth2.client.registration.google.client-name=google
 spring.security.oauth2.client.registration.google.client-id=ENC(09sVzBogF2PpwmAPCWIKTopMC3Vw6SGtka+6t7ugKtLVmJlLpcNuBLmidZLuvxRp2UocWP+RED2DWIA9Y3N9JPofEtexkPW69+iDPrrvr52mpDciXZHWag==)
 spring.security.oauth2.client.registration.google.client-secret=ENC(KhB+BeKxWiw1lSVJyCrBANnNhg6cFI4lHN/Sql5CS7ArBODznDn0K+foxzXvsrH7)
@@ -45,7 +42,7 @@ spring.security.oauth2.client.registration.google.redirect-uri=http://localhost:
 spring.security.oauth2.client.registration.google.authorization-grant-type=authorization_code
 spring.security.oauth2.client.registration.google.scope=profile,email
 
-# ncp Object Storage ??
+# ncp Object Storage
 ncp.end-point=ENC(XlMl/6AGqbbWN6lF8+Cf/iSIWwW4ajrmo8HyJYeXCtr1Qugi1Pg/YfVEVWpCIBzH)
 ncp.region-name=ENC(zyUgEYXdPuMn5ZBJzPhI+QcJqS16MsoD)
 ncp.access-key=ENC(3dxh0Lma8YlSI3ZhR9RV8OOTAZSFx82ylkoTXi4/iPktQPnBebmtHw==)
@@ -53,3 +50,12 @@ ncp.secret-key=ENC(qvBnQYNSmalRQTIuUq5CSUAkG1TYQJPQgGAITXQ6AGvMfp9c4krVnNHOkA2Xa
 ncp.bucket-name=ENC(6zQUtJUN2CulvBcAjhbTY+XI6d6KgP+P)
 
 spring.web.resources.static-locations=classpath:/static/
+
+# Flyway \uC124\uC815
+spring.flyway.enabled=true
+spring.flyway.baseline-on-migrate=true
+spring.flyway.locations=classpath:db/migration
+spring.flyway.schemas=imjm
+spring.flyway.default-schema=imjm
+spring.flyway.baseline-version=0
+spring.flyway.validate-on-migrate=true

--- a/IMJM-server/src/main/resources/db/migration/V1__INIT.sql
+++ b/IMJM-server/src/main/resources/db/migration/V1__INIT.sql
@@ -1,0 +1,313 @@
+CREATE TABLE users (
+                       id VARCHAR(100),
+                       user_type VARCHAR(20),
+                       first_name VARCHAR(50),
+                       last_name VARCHAR(20),
+                       language VARCHAR(20),
+                       email VARCHAR(50),
+                       gender VARCHAR(20),
+                       nickname VARCHAR(50),
+                       profile VARCHAR(255),
+                       birthday DATE,
+                       region VARCHAR(15),
+                       point INT DEFAULT 0,
+                       is_notification BOOLEAN DEFAULT true,
+                       address VARCHAR(255),
+                       latitude DECIMAL(10, 8),
+                       longitude DECIMAL(11, 8),
+                       PRIMARY KEY (id),
+                       CONSTRAINT unique_email UNIQUE (email),
+                       CONSTRAINT unique_nickname UNIQUE (nickname)
+);
+
+CREATE TABLE member (
+                        user_id VARCHAR(100),
+                        history VARCHAR(50),
+                        washing_hair VARCHAR(20),
+                        PRIMARY KEY (user_id),
+                        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE client_stylist (
+                                user_id VARCHAR(100),
+                                salon_name VARCHAR(50),
+                                license VARCHAR(255),
+                                PRIMARY KEY (user_id),
+                                FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE salon (
+                       id VARCHAR(20) NOT NULL,
+                       password VARCHAR(100) NOT NULL,
+                       name VARCHAR(50) NOT NULL,
+                       corp_reg_number VARCHAR(20),
+                       address VARCHAR(255),
+                       call_number VARCHAR(20),
+                       introduction TEXT,
+                       holiday_mask SMALLINT NOT NULL DEFAULT 0,
+                       start_time TIME,
+                       end_time TIME,
+                       time_unit INT,
+                       score DECIMAL(2, 1),
+                       latitude DECIMAL(10, 8),
+                       longitude DECIMAL(11, 8),
+                       PRIMARY KEY (id)
+);
+
+CREATE TABLE salon_photos (
+                              photo_id BIGSERIAL,
+                              salon_id VARCHAR(20) NOT NULL,
+                              photo_url VARCHAR(255) NOT NULL,
+                              photo_order INT NOT NULL,
+                              upload_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                              PRIMARY KEY (photo_id),
+                              FOREIGN KEY (salon_id) REFERENCES salon(id) ON DELETE CASCADE
+);
+
+CREATE TABLE service_menu (
+                              id BIGSERIAL,
+                              salon_id VARCHAR(20) NOT NULL,
+                              service_type VARCHAR(100) NOT NULL,
+                              service_name VARCHAR(100) NOT NULL,
+                              service_description TEXT,
+                              price INT NOT NULL,
+                              PRIMARY KEY (id),
+                              FOREIGN KEY (salon_id) REFERENCES salon(id) ON DELETE CASCADE
+);
+
+CREATE TABLE admin_stylist (
+                               stylist_id BIGSERIAL NOT NULL,
+                               salon_id VARCHAR(20) NOT NULL,
+                               name VARCHAR(10) NOT NULL,
+                               call_number VARCHAR(20),
+                               start_time TIME,
+                               end_time TIME,
+                               holiday_mask SMALLINT NOT NULL DEFAULT 0,
+                               profile VARCHAR(255),
+                               introduction TEXT,
+                               PRIMARY KEY (stylist_id),
+                               FOREIGN KEY (salon_id) REFERENCES salon(id) ON DELETE CASCADE
+);
+
+CREATE TABLE reservation (
+                             id BIGSERIAL NOT NULL,
+                             user_id VARCHAR(100) NOT NULL,
+                             stylist_id BIGINT NOT NULL,
+                             reservation_date DATE NOT NULL,
+                             reservation_time TIME NOT NULL,
+                             service_type VARCHAR(100) NOT NULL,
+                             service_name VARCHAR(100) NOT NULL,
+                             price INT NOT NULL,
+                             is_paid BOOLEAN NOT NULL,
+                             requirements TEXT,
+                             PRIMARY KEY (id),
+                             FOREIGN KEY (user_id) REFERENCES users(id),
+                             FOREIGN KEY (stylist_id) REFERENCES admin_stylist(stylist_id),
+                             CONSTRAINT unique_reservation UNIQUE (stylist_id, reservation_date, reservation_time)
+);
+
+CREATE TABLE review (
+                        id BIGSERIAL NOT NULL,
+                        user_id VARCHAR(100) NOT NULL,
+                        salon_id VARCHAR(20) NOT NULL,
+                        reg_date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                        score DECIMAL(2, 1) NOT NULL,
+                        content TEXT,
+                        review_tag VARCHAR(100),
+                        reservation_id BIGINT,
+                        PRIMARY KEY (id),
+                        FOREIGN KEY (user_id) REFERENCES users(id),
+                        FOREIGN KEY (salon_id) REFERENCES salon(id),
+                        FOREIGN KEY (reservation_id) REFERENCES reservation(id)
+);
+
+CREATE TABLE review_photos (
+                               photo_id BIGSERIAL,
+                               review_id BIGINT NOT NULL,
+                               photo_url VARCHAR(255) NOT NULL,
+                               photo_order INT NOT NULL,
+                               upload_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                               PRIMARY KEY (photo_id),
+                               FOREIGN KEY (review_id) REFERENCES review(id) ON DELETE CASCADE
+);
+
+CREATE TABLE point_usage (
+                             id BIGSERIAL NOT NULL,
+                             user_id VARCHAR(100) NOT NULL,
+                             usage_type VARCHAR(20) NOT NULL,
+                             price INT NOT NULL,
+                             use_date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                             content VARCHAR(100) NOT NULL,
+                             PRIMARY KEY (id),
+                             FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE TABLE archive (
+                         id BIGSERIAL NOT NULL,
+                         user_id VARCHAR(100) NOT NULL,
+                         content TEXT,
+                         service VARCHAR(50),
+                         gender VARCHAR(10),
+                         color VARCHAR(50),
+                         length VARCHAR(50),
+                         reg_date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                         PRIMARY KEY (id),
+                         FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE archive_photos (
+                                photo_id BIGSERIAL,
+                                archive_id BIGINT NOT NULL,
+                                photo_url VARCHAR(255) NOT NULL,
+                                photo_order INT NOT NULL,
+                                upload_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                                PRIMARY KEY (photo_id),
+                                FOREIGN KEY (archive_id) REFERENCES archive(id) ON DELETE CASCADE
+);
+
+CREATE TABLE archive_like (
+                              archive_id BIGINT NOT NULL,
+                              user_id VARCHAR(100) NOT NULL,
+                              PRIMARY KEY (archive_id, user_id),
+                              FOREIGN KEY (archive_id) REFERENCES archive(id) ON DELETE CASCADE,
+                              FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE TABLE archive_comment (
+                                 id BIGSERIAL NOT NULL,
+                                 archive_id BIGINT NOT NULL,
+                                 user_id VARCHAR(100) NOT NULL,
+                                 reg_date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                 content TEXT,
+                                 is_comment_for_comment BOOLEAN NOT NULL DEFAULT FALSE,
+                                 parent_comment_id BIGINT,
+                                 PRIMARY KEY (id),
+                                 FOREIGN KEY (archive_id) REFERENCES archive(id) ON DELETE CASCADE,
+                                 FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+ALTER TABLE archive_comment ADD FOREIGN KEY (parent_comment_id) REFERENCES archive_comment(id);
+
+CREATE TABLE community (
+                           id BIGSERIAL NOT NULL,
+                           user_id VARCHAR(100) NOT NULL,
+                           title VARCHAR(100) NOT NULL,
+                           content TEXT NOT NULL,
+                           reg_date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                           PRIMARY KEY (id),
+                           FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE TABLE community_photos (
+                                  photo_id BIGSERIAL,
+                                  community_id BIGINT NOT NULL,
+                                  photo_url VARCHAR(255) NOT NULL,
+                                  photo_order INT NOT NULL,
+                                  upload_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                                  PRIMARY KEY (photo_id),
+                                  FOREIGN KEY (community_id) REFERENCES community(id) ON DELETE CASCADE
+);
+
+CREATE TABLE community_like (
+                                community_id BIGINT NOT NULL,
+                                user_id VARCHAR(100) NOT NULL,
+                                PRIMARY KEY (community_id, user_id),
+                                FOREIGN KEY (community_id) REFERENCES community(id) ON DELETE CASCADE,
+                                FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+CREATE TABLE community_comment (
+                                   id BIGSERIAL NOT NULL,
+                                   community_id BIGINT NOT NULL,
+                                   user_id VARCHAR(100) NOT NULL,
+                                   reg_date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                                   content TEXT,
+                                   is_comment_for_comment BOOLEAN NOT NULL DEFAULT FALSE,
+                                   parent_comment_id BIGINT,
+                                   PRIMARY KEY (id),
+                                   FOREIGN KEY (community_id) REFERENCES community(id) ON DELETE CASCADE,
+                                   FOREIGN KEY (user_id) REFERENCES users(id)
+);
+
+ALTER TABLE community_comment ADD FOREIGN KEY (parent_comment_id) REFERENCES community_comment(id);
+
+CREATE TABLE payment (
+                         reservation_id BIGINT NOT NULL,
+                         user_id VARCHAR(100) NOT NULL,
+                         price INT NOT NULL,
+                         payment_method VARCHAR(50) NOT NULL,
+                         payment_status VARCHAR(20) NOT NULL,
+                         transaction_id VARCHAR(100),
+                         payment_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                         is_canceled BOOLEAN DEFAULT FALSE,
+                         canceled_amount DECIMAL(10, 2) DEFAULT 0.00,
+                         canceled_at TIMESTAMP NULL,
+                         is_refunded BOOLEAN DEFAULT FALSE,
+                         FOREIGN KEY (reservation_id) REFERENCES reservation(id),
+                         FOREIGN KEY (user_id) REFERENCES users(id),
+                         PRIMARY KEY (reservation_id, user_id)
+);
+
+CREATE TABLE alarm (
+                       id BIGSERIAL,
+                       user_id VARCHAR(100) NOT NULL,
+                       title VARCHAR(100) NOT NULL,
+                       content TEXT NOT NULL,
+                       is_read BOOLEAN DEFAULT FALSE,
+                       notification_type VARCHAR(50),
+                       reference_id BIGINT,
+                       created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                       PRIMARY KEY (id),
+                       FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE chat_room (
+                           id BIGSERIAL,
+                           user_id VARCHAR(100) NOT NULL,
+                           salon_id VARCHAR(20) NOT NULL,
+                           created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                           last_message_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                           PRIMARY KEY (id),
+                           FOREIGN KEY (user_id) REFERENCES users(id),
+                           FOREIGN KEY (salon_id) REFERENCES salon(id),
+                           CONSTRAINT unique_chat UNIQUE (user_id, salon_id)
+);
+
+CREATE TABLE chat_message (
+                              id BIGSERIAL,
+                              chat_room_id BIGINT NOT NULL,
+                              sender_type VARCHAR(20) NOT NULL,
+                              message TEXT NOT NULL,
+                              is_read BOOLEAN DEFAULT FALSE,
+                              sent_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                              translated_message TEXT,
+                              translation_status VARCHAR(10) DEFAULT 'none',
+                              PRIMARY KEY (id),
+                              FOREIGN KEY (chat_room_id) REFERENCES chat_room(id) ON DELETE CASCADE
+);
+
+CREATE TABLE translation_cache (
+                                   id BIGSERIAL,
+                                   source_text TEXT NOT NULL,
+                                   source_language VARCHAR(10) NOT NULL,
+                                   target_language VARCHAR(10) NOT NULL,
+                                   translated_text TEXT NOT NULL,
+                                   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                                   last_used_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                                   use_count INT DEFAULT 1,
+                                   text_hash VARCHAR(64) NOT NULL,
+                                   PRIMARY KEY (id),
+                                   CONSTRAINT unique_translation UNIQUE (text_hash, source_language, target_language)
+);
+
+CREATE INDEX idx_last_used ON translation_cache (last_used_at);
+
+CREATE TABLE blacklist (
+                           salon_id VARCHAR(20) NOT NULL,
+                           user_id VARCHAR(100) NOT NULL,
+                           reason TEXT,
+                           blocked_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                           PRIMARY KEY (salon_id, user_id),
+                           FOREIGN KEY (salon_id) REFERENCES salon(id) ON DELETE CASCADE,
+                           FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/IMJM-server/src/main/resources/db/migration/V2__ALTER_USER_TERMS_AGREED.sql
+++ b/IMJM-server/src/main/resources/db/migration/V2__ALTER_USER_TERMS_AGREED.sql
@@ -1,0 +1,5 @@
+ALTER TABLE users
+    ADD COLUMN terms_agreed BOOLEAN DEFAULT false;
+
+ALTER TABLE salon
+    ADD COLUMN detail_address VARCHAR(255);

--- a/IMJM-server/src/main/resources/db/migration/V3__ADD_CHAT_PHOTOS.sql
+++ b/IMJM-server/src/main/resources/db/migration/V3__ADD_CHAT_PHOTOS.sql
@@ -1,0 +1,8 @@
+CREATE TABLE chat_photos (
+    photo_id BIGSERIAL,
+    chat_message_id BIGINT NOT NULL,
+    photo_url VARCHAR(255) NOT NULL,
+    upload_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (photo_id),
+    FOREIGN KEY (chat_message_id) REFERENCES chat_message(id) ON DELETE CASCADE
+);

--- a/IMJM-server/src/main/resources/static/chat-test.html
+++ b/IMJM-server/src/main/resources/static/chat-test.html
@@ -6,44 +6,181 @@
     <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"></script>
     <style>
+        body {
+            font-family: 'Arial', sans-serif;
+            margin: 0;
+            padding: 0;
+            background-color: #f5f5f5;
+        }
         .container {
-            max-width: 700px;
+            max-width: 1000px;
             margin: 0 auto;
             padding: 20px;
+            display: flex;
+            flex-direction: column;
+            height: 100vh;
+        }
+        .header {
+            display: flex;
+            justify-content: space-between;
+            margin-bottom: 15px;
+            background-color: #fff;
+            padding: 15px;
+            border-radius: 8px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+        }
+        .connection-settings, .chat-room-settings {
+            margin-bottom: 5px;
+        }
+        .main-content {
+            display: flex;
+            flex-grow: 1;
+            height: calc(100vh - 180px);
+        }
+        .chat-rooms-panel {
+            width: 30%;
+            background-color: #fff;
+            margin-right: 20px;
+            border-radius: 8px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+            overflow-y: auto;
+        }
+        .chat-window-panel {
+            width: 70%;
+            display: flex;
+            flex-direction: column;
+            background-color: #fff;
+            border-radius: 8px;
+            box-shadow: 0 1px 3px rgba(0,0,0,0.1);
         }
         .chat-window {
-            height: 400px;
-            border: 1px solid #ddd;
-            padding: 10px;
+            flex-grow: 1;
+            padding: 15px;
             overflow-y: auto;
-            margin-bottom: 10px;
+            background-color: #f9f9f9;
         }
         .message-form {
             display: flex;
+            padding: 10px;
+            border-top: 1px solid #eee;
         }
         .message-input {
             flex-grow: 1;
-            padding: 8px;
+            padding: 10px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+            margin-right: 10px;
         }
         .user-message {
             background-color: #e1ffc7;
-            padding: 8px;
-            border-radius: 5px;
+            padding: 10px;
+            border-radius: 8px;
             margin-bottom: 10px;
             max-width: 70%;
             align-self: flex-end;
             margin-left: auto;
+            position: relative;
         }
         .salon-message {
             background-color: #f0f0f0;
-            padding: 8px;
-            border-radius: 5px;
+            padding: 10px;
+            border-radius: 8px;
             margin-bottom: 10px;
             max-width: 70%;
+            position: relative;
+        }
+        .chat-room-item {
+            padding: 15px;
+            border-bottom: 1px solid #eee;
+            cursor: pointer;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        .chat-room-item:hover {
+            background-color: #f5f5f5;
+        }
+        .chat-room-item.active {
+            background-color: #e8f4ff;
+        }
+        .has-unread {
+            font-weight: bold;
+        }
+        .unread-badge {
+            background-color: #ff4d4f;
+            color: white;
+            border-radius: 50%;
+            padding: 2px 8px;
+            font-size: 12px;
+        }
+        .room-info {
+            flex-grow: 1;
+        }
+        .room-name {
+            font-weight: 500;
+            margin-bottom: 3px;
+        }
+        .last-message {
+            font-size: 13px;
+            color: #888;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            max-width: 200px;
+        }
+        .message-status {
+            text-align: right;
+            font-size: 12px;
+            color: #888;
+            margin-top: 2px;
+        }
+        .read-status {
+            color: #2196f3;
+        }
+        .message-time {
+            font-size: 11px;
+            color: #888;
+            margin-top: 2px;
         }
         button {
             padding: 8px 15px;
-            margin-left: 5px;
+            background-color: #4c9aff;
+            border: none;
+            color: white;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        button:hover {
+            background-color: #3a8ae6;
+        }
+        button:disabled {
+            background-color: #cccccc;
+            cursor: not-allowed;
+        }
+        input, select {
+            padding: 8px;
+            border: 1px solid #ddd;
+            border-radius: 4px;
+        }
+        label {
+            margin-right: 5px;
+        }
+        .form-group {
+            display: flex;
+            align-items: center;
+            margin-right: 10px;
+        }
+
+        .message-translated {
+            font-style: italic;
+            margin-top: 5px;
+            font-size: 0.9em;
+            color: #666;
+        }
+
+        .translation-label {
+            font-weight: bold;
+            color: #2196f3;
         }
     </style>
 </head>
@@ -51,34 +188,59 @@
 <div class="container">
     <h2>이모저모 채팅 테스트</h2>
 
-    <div>
-        <label for="user-id">사용자 ID:</label>
-        <input type="text" id="user-id" value="user1">
+    <div class="header">
+        <div class="connection-settings">
+            <div class="form-group">
+                <label for="user-id">사용자 ID:</label>
+                <input type="text" id="user-id" value="user1">
+            </div>
 
-        <label for="salon-id">미용실 ID:</label>
-        <input type="text" id="salon-id" value="salon1">
+            <div class="form-group">
+                <label for="salon-id">미용실 ID:</label>
+                <input type="text" id="salon-id" value="salon1">
+            </div>
 
-        <label for="sender-type">보내는 사람 타입:</label>
-        <select id="sender-type">
-            <option value="USER">사용자</option>
-            <option value="SALON">미용실</option>
-        </select>
+            <div class="form-group">
+                <label for="sender-type">보내는 사람 타입:</label>
+                <select id="sender-type">
+                    <option value="USER">사용자</option>
+                    <option value="SALON">미용실</option>
+                </select>
+            </div>
+        </div>
 
-        <button onclick="connect()">연결</button>
-        <button onclick="disconnect()">연결 해제</button>
+        <div>
+            <button onclick="connect()" id="connect-btn">연결</button>
+            <button onclick="disconnect()" id="disconnect-btn" disabled>연결 해제</button>
+        </div>
     </div>
 
-    <div>
-        <label for="chat-room-id">채팅방 ID:</label>
-        <input type="text" id="chat-room-id">
-        <button onclick="createChatRoom()">채팅방 생성/조회</button>
+    <div class="chat-room-settings">
+        <div class="form-group">
+            <label for="chat-room-id">채팅방 ID:</label>
+            <input type="text" id="chat-room-id" readonly>
+        </div>
+        <button onclick="createChatRoom()" id="create-room-btn" disabled>채팅방 생성/조회</button>
     </div>
 
-    <div class="chat-window" id="chat-messages"></div>
+    <div class="main-content">
+        <div class="chat-rooms-panel" id="chat-rooms-list">
+            <!-- 채팅방 목록이 여기에 표시됩니다 -->
+        </div>
 
-    <div class="message-form">
-        <input type="text" id="message" class="message-input" placeholder="메시지 입력...">
-        <button onclick="sendMessage()">전송</button>
+        <div class="chat-window-panel">
+            <div class="chat-window" id="chat-messages">
+                <!-- 메시지가 여기에 표시됩니다 -->
+                <div class="welcome-message" style="text-align: center; color: #888; margin-top: 20px;">
+                    채팅방을 선택하세요
+                </div>
+            </div>
+
+            <div class="message-form">
+                <input type="text" id="message" class="message-input" placeholder="메시지 입력..." disabled>
+                <button onclick="sendMessage()" id="send-btn" disabled>전송</button>
+            </div>
+        </div>
     </div>
 </div>
 
@@ -88,23 +250,71 @@
     let currentSalonId = null;
     let currentSenderType = null;
     let currentChatRoomId = null;
+    let isSubmitting = false;
+
+    // 페이지 로드 시 초기화
+    window.onload = function() {
+        document.getElementById('message').addEventListener('keypress', function(e) {
+            if (e.key === 'Enter') {
+                sendMessage();
+            }
+        });
+    };
+
+    // 자동 업데이트 인터벌 변수
+    let autoUpdateInterval = null;
+
+    // 자동 업데이트 시작
+    function startAutoUpdate() {
+        // 이미 실행 중인 인터벌이 있다면 중지
+        if (autoUpdateInterval) {
+            clearInterval(autoUpdateInterval);
+        }
+
+        // 5초마다 채팅방 목록과 현재 채팅방의 메시지를 업데이트
+        autoUpdateInterval = setInterval(() => {
+            updateChatRoomsList();
+            if (currentChatRoomId) {
+                loadMessages(false); // false는 조용히 업데이트
+            }
+        }, 5000);
+    }
+
+    // 자동 업데이트 중지
+    function stopAutoUpdate() {
+        if (autoUpdateInterval) {
+            clearInterval(autoUpdateInterval);
+            autoUpdateInterval = null;
+        }
+    }
+
 
     function connect() {
         currentUserId = document.getElementById('user-id').value;
         currentSalonId = document.getElementById('salon-id').value;
         currentSenderType = document.getElementById('sender-type').value;
 
+        if (!currentUserId || !currentSalonId) {
+            alert('사용자 ID와 미용실 ID를 입력해주세요.');
+            return;
+        }
+
         console.log('연결 시도:', {userId: currentUserId, salonId: currentSalonId, senderType: currentSenderType});
 
         const socket = new SockJS('/ws');
         stompClient = Stomp.over(socket);
 
-        // 로그 출력 활성화
-        stompClient.debug = function(str) {
-            console.log('STOMP: ' + str);
+        // 로그 최소화 (필요한 경우 주석 해제)
+        stompClient.debug = null; // 로그 출력 비활성화
+
+        // 연결 헤더 추가 (사용자 식별 용도)
+        const headers = {
+            'userId': currentUserId,
+            'salonId': currentSalonId,
+            'senderType': currentSenderType
         };
 
-        stompClient.connect({}, function(frame) {
+        stompClient.connect(headers, function(frame) {
             console.log('Connected: ' + frame);
 
             // 사용자 ID로 구독
@@ -112,24 +322,102 @@
             console.log('구독 경로:', destination);
 
             stompClient.subscribe(destination, onMessageReceived);
+
+            // UI 업데이트
+            document.getElementById('connect-btn').disabled = true;
+            document.getElementById('disconnect-btn').disabled = false;
+            document.getElementById('create-room-btn').disabled = false;
+
+            // 채팅방 목록 로드
+            updateChatRoomsList();
+
             alert('웹소켓 연결 성공!');
+
+            // 자동 주기적 업데이트 시작
+            startAutoUpdate();
         }, function(error) {
             console.error('연결 오류:', error);
             alert('연결 오류가 발생했습니다: ' + error);
         });
     }
 
-    function onError(error) {
-        console.error('연결 오류: ', error);
-        alert('연결 오류가 발생했습니다.');
-    }
 
     function disconnect() {
+        stopAutoUpdate();
+
         if (stompClient !== null) {
             stompClient.disconnect();
+            stompClient = null;
+
+            // UI 업데이트
+            document.getElementById('connect-btn').disabled = false;
+            document.getElementById('disconnect-btn').disabled = true;
+            document.getElementById('create-room-btn').disabled = true;
+            document.getElementById('message').disabled = true;
+            document.getElementById('send-btn').disabled = true;
+            document.getElementById('chat-room-id').value = '';
+            document.getElementById('chat-messages').innerHTML = '<div class="welcome-message" style="text-align: center; color: #888; margin-top: 20px;">채팅방을 선택하세요</div>';
+            document.getElementById('chat-rooms-list').innerHTML = '';
+
+            currentChatRoomId = null;
+
+            console.log("연결 해제됨");
+            alert('연결이 해제되었습니다.');
         }
-        console.log("연결 해제됨");
-        alert('연결이 해제되었습니다.');
+    }
+
+    function updateChatRoomsList() {
+        if (!stompClient) return;
+
+        const endpoint = currentSenderType === 'USER'
+            ? `/api/chat/rooms/user/${currentUserId}`
+            : `/api/chat/rooms/salon/${currentSalonId}`;
+
+        fetch(endpoint)
+            .then(response => response.json())
+            .then(rooms => {
+                const roomsList = document.getElementById('chat-rooms-list');
+                roomsList.innerHTML = '';
+
+                if (rooms.length === 0) {
+                    roomsList.innerHTML = '<div style="padding: 15px; color: #888; text-align: center;">채팅방이 없습니다</div>';
+                    return;
+                }
+
+                rooms.forEach(room => {
+                    const roomElement = document.createElement('div');
+                    roomElement.classList.add('chat-room-item');
+                    if (room.id === currentChatRoomId) {
+                        roomElement.classList.add('active');
+                    }
+                    if (room.hasUnreadMessages) {
+                        roomElement.classList.add('has-unread');
+                    }
+
+                    const unreadBadge = room.unreadCount > 0
+                        ? `<span class="unread-badge">${room.unreadCount}</span>`
+                        : '';
+
+                    const otherName = currentSenderType === 'USER' ? room.salonName : room.userName;
+
+                    roomElement.innerHTML = `
+                    <div class="room-info">
+                        <div class="room-name">${otherName}</div>
+                        <div class="last-message">${room.lastMessage || '메시지 없음'}</div>
+                    </div>
+                    ${unreadBadge}
+                `;
+
+                    roomElement.addEventListener('click', () => {
+                        openChatRoom(room.id);
+                    });
+
+                    roomsList.appendChild(roomElement);
+                });
+            })
+            .catch(error => {
+                console.error('채팅방 목록 로드 오류:', error);
+            });
     }
 
     function createChatRoom() {
@@ -141,13 +429,21 @@
         })
             .then(response => response.json())
             .then(data => {
-                currentChatRoomId = parseInt(data.id, 10); // 문자열을 숫자로 변환
+                currentChatRoomId = parseInt(data.id, 10);
                 document.getElementById('chat-room-id').value = currentChatRoomId;
                 console.log('채팅방 생성/조회 성공:', data);
-                alert('채팅방 생성/조회 성공! 채팅방 ID: ' + currentChatRoomId);
+
+                // UI 활성화
+                document.getElementById('message').disabled = false;
+                document.getElementById('send-btn').disabled = false;
+
+                // 채팅방 목록 업데이트
+                updateChatRoomsList();
 
                 // 기존 메시지 로드
                 loadMessages();
+
+                alert('채팅방 생성/조회 성공! 채팅방 ID: ' + currentChatRoomId);
             })
             .catch(error => {
                 console.error('채팅방 생성/조회 오류:', error);
@@ -155,9 +451,47 @@
             });
     }
 
-    function loadMessages() {
+    function openChatRoom(roomId) {
+        currentChatRoomId = roomId;
+        document.getElementById('chat-room-id').value = currentChatRoomId;
+
+        // UI 활성화
+        document.getElementById('message').disabled = false;
+        document.getElementById('send-btn').disabled = false;
+
+        // 채팅방 목록에서 활성화된 항목 표시
+        const roomItems = document.querySelectorAll('.chat-room-item');
+        roomItems.forEach(item => {
+            item.classList.remove('active');
+        });
+
+        const activeRoom = Array.from(roomItems).find(item =>
+            item.querySelector('.room-name').textContent ===
+            (currentSenderType === 'USER' ? getSalonNameById(roomId) : getUserNameById(roomId))
+        );
+
+        if (activeRoom) {
+            activeRoom.classList.add('active');
+        }
+
+        // 기존 메시지 로드
+        loadMessages();
+    }
+
+    // 샵 이름과 유저 이름을 얻는 함수 (실제로는 API 호출로 대체될 수 있음)
+    function getSalonNameById(roomId) {
+        const roomElement = document.querySelector(`.chat-room-item[data-id="${roomId}"]`);
+        return roomElement ? roomElement.querySelector('.room-name').textContent : '';
+    }
+
+    function getUserNameById(roomId) {
+        const roomElement = document.querySelector(`.chat-room-item[data-id="${roomId}"]`);
+        return roomElement ? roomElement.querySelector('.room-name').textContent : '';
+    }
+
+    function loadMessages(showAlert = true) {
         if (!currentChatRoomId) {
-            alert('채팅방을 먼저 선택해주세요.');
+            if (showAlert) alert('채팅방을 먼저 선택해주세요.');
             return;
         }
 
@@ -167,16 +501,41 @@
                 const messageArea = document.getElementById('chat-messages');
                 messageArea.innerHTML = '';
 
+                if (data.length === 0) {
+                    messageArea.innerHTML = '<div style="text-align: center; color: #888; margin-top: 20px;">메시지가 없습니다. 첫 메시지를 보내보세요!</div>';
+                    return;
+                }
+
                 data.forEach(msg => {
                     addMessageToUI(msg);
                 });
+
+                // 스크롤을 맨 아래로 이동
+                messageArea.scrollTop = messageArea.scrollHeight;
+
+                // 채팅방에 접속했을 때 자동으로 읽음 처리
+                markAsRead();
             })
             .catch(error => {
                 console.error('메시지 로드 오류:', error);
+                if (showAlert) alert('메시지 로드 중 오류가 발생했습니다.');
             });
     }
 
-    let isSubmitting = false;
+    function markAsRead() {
+        fetch(`/api/chat/messages/read/${currentChatRoomId}?senderType=${currentSenderType}`, {
+            method: 'PUT'
+        })
+            .then(response => response.json())
+            .then(data => {
+                console.log('읽음 처리 완료:', data);
+                // 채팅방 목록 업데이트
+                updateChatRoomsList();
+            })
+            .catch(error => {
+                console.error('읽음 처리 오류:', error);
+            });
+    }
 
     function sendMessage() {
         if (!stompClient || !currentChatRoomId || isSubmitting) {
@@ -200,8 +559,29 @@
 
             console.log('전송할 메시지:', chatMessage);
 
+            // 메시지를 UI에 먼저 추가 (낙관적 업데이트)
+            const tempMessage = {
+                id: Date.now(), // 임시 ID
+                chatRoomId: chatMessage.chatRoomId,
+                senderType: chatMessage.senderType,
+                senderId: chatMessage.senderId,
+                message: chatMessage.message,
+                isRead: false,
+                sentAt: new Date(),
+                photos: []
+            };
+            addMessageToUI(tempMessage);
+
+            // 스크롤을 맨 아래로 이동
+            const messageArea = document.getElementById('chat-messages');
+            messageArea.scrollTop = messageArea.scrollHeight;
+
+            // 메시지 전송
             stompClient.send("/app/chat.sendMessage", {}, JSON.stringify(chatMessage));
             messageInput.value = '';
+
+            // 채팅방 목록 즉시 업데이트 (낙관적 업데이트)
+            setTimeout(updateChatRoomsList, 100);
 
             // 0.5초 후에 다시 전송 가능하도록 설정
             setTimeout(() => {
@@ -212,7 +592,24 @@
 
     function onMessageReceived(payload) {
         const message = JSON.parse(payload.body);
-        addMessageToUI(message);
+        console.log('수신된 메시지:', message);
+
+        // 현재 활성화된 채팅방인 경우에만 메시지 표시
+        if (currentChatRoomId === message.chatRoomId) {
+            addMessageToUI(message);
+
+            // 자동으로 스크롤 맨 아래로 이동
+            const messageArea = document.getElementById('chat-messages');
+            messageArea.scrollTop = messageArea.scrollHeight;
+
+            // 현재 활성화된 채팅방이고 상대방이 보낸 메시지면 자동으로 읽음 처리
+            if (message.senderType !== currentSenderType) {
+                markAsRead();
+            }
+        }
+
+        // 채팅방 목록 업데이트
+        updateChatRoomsList();
     }
 
     function addMessageToUI(message) {
@@ -224,10 +621,29 @@
 
         const time = new Date(message.sentAt).toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'});
 
-        messageElement.innerHTML = `
-            <div><strong>${message.senderType}</strong> (${time})</div>
-            <div>${message.message}</div>
+        // 읽음 상태 표시 추가
+        const readStatus = message.isRead ? '<span class="read-status">읽음</span>' : '';
+
+        // 원본 메시지와 번역된 메시지를 함께 표시
+        let messageContent = `<div class="message-original">${message.message}</div>`;
+
+        // 번역된 메시지가 있으면 표시
+        if (message.translatedMessage && message.translationStatus === 'completed') {
+            messageContent += `
+            <div class="message-translated">
+                <span class="translation-label">번역:</span> ${message.translatedMessage}
+            </div>
         `;
+        }
+
+        messageElement.innerHTML = `
+        <div>
+            <strong>${message.senderType === 'USER' ? '사용자' : '미용실'}</strong>
+            <span class="message-time">(${time})</span>
+        </div>
+        ${messageContent}
+        <div class="message-status">${readStatus}</div>
+    `;
 
         // 사진이 있는 경우 처리
         if (message.photos && message.photos.length > 0) {
@@ -240,6 +656,7 @@
                 img.style.maxWidth = '200px';
                 img.style.maxHeight = '200px';
                 img.style.marginRight = '5px';
+                img.style.borderRadius = '4px';
                 photosDiv.appendChild(img);
             });
 
@@ -247,7 +664,6 @@
         }
 
         messageArea.appendChild(messageElement);
-        messageArea.scrollTop = messageArea.scrollHeight;
     }
 </script>
 </body>

--- a/IMJM-server/src/main/resources/static/chat-test.html
+++ b/IMJM-server/src/main/resources/static/chat-test.html
@@ -1,0 +1,254 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>채팅 테스트</title>
+    <meta charset="UTF-8">
+    <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/stomp.js/2.3.3/stomp.min.js"></script>
+    <style>
+        .container {
+            max-width: 700px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        .chat-window {
+            height: 400px;
+            border: 1px solid #ddd;
+            padding: 10px;
+            overflow-y: auto;
+            margin-bottom: 10px;
+        }
+        .message-form {
+            display: flex;
+        }
+        .message-input {
+            flex-grow: 1;
+            padding: 8px;
+        }
+        .user-message {
+            background-color: #e1ffc7;
+            padding: 8px;
+            border-radius: 5px;
+            margin-bottom: 10px;
+            max-width: 70%;
+            align-self: flex-end;
+            margin-left: auto;
+        }
+        .salon-message {
+            background-color: #f0f0f0;
+            padding: 8px;
+            border-radius: 5px;
+            margin-bottom: 10px;
+            max-width: 70%;
+        }
+        button {
+            padding: 8px 15px;
+            margin-left: 5px;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h2>이모저모 채팅 테스트</h2>
+
+    <div>
+        <label for="user-id">사용자 ID:</label>
+        <input type="text" id="user-id" value="user1">
+
+        <label for="salon-id">미용실 ID:</label>
+        <input type="text" id="salon-id" value="salon1">
+
+        <label for="sender-type">보내는 사람 타입:</label>
+        <select id="sender-type">
+            <option value="USER">사용자</option>
+            <option value="SALON">미용실</option>
+        </select>
+
+        <button onclick="connect()">연결</button>
+        <button onclick="disconnect()">연결 해제</button>
+    </div>
+
+    <div>
+        <label for="chat-room-id">채팅방 ID:</label>
+        <input type="text" id="chat-room-id">
+        <button onclick="createChatRoom()">채팅방 생성/조회</button>
+    </div>
+
+    <div class="chat-window" id="chat-messages"></div>
+
+    <div class="message-form">
+        <input type="text" id="message" class="message-input" placeholder="메시지 입력...">
+        <button onclick="sendMessage()">전송</button>
+    </div>
+</div>
+
+<script>
+    let stompClient = null;
+    let currentUserId = null;
+    let currentSalonId = null;
+    let currentSenderType = null;
+    let currentChatRoomId = null;
+
+    function connect() {
+        currentUserId = document.getElementById('user-id').value;
+        currentSalonId = document.getElementById('salon-id').value;
+        currentSenderType = document.getElementById('sender-type').value;
+
+        console.log('연결 시도:', {userId: currentUserId, salonId: currentSalonId, senderType: currentSenderType});
+
+        const socket = new SockJS('/ws');
+        stompClient = Stomp.over(socket);
+
+        // 로그 출력 활성화
+        stompClient.debug = function(str) {
+            console.log('STOMP: ' + str);
+        };
+
+        stompClient.connect({}, function(frame) {
+            console.log('Connected: ' + frame);
+
+            // 사용자 ID로 구독
+            const destination = '/user/' + (currentSenderType === 'USER' ? currentUserId : currentSalonId) + '/queue/messages';
+            console.log('구독 경로:', destination);
+
+            stompClient.subscribe(destination, onMessageReceived);
+            alert('웹소켓 연결 성공!');
+        }, function(error) {
+            console.error('연결 오류:', error);
+            alert('연결 오류가 발생했습니다: ' + error);
+        });
+    }
+
+    function onError(error) {
+        console.error('연결 오류: ', error);
+        alert('연결 오류가 발생했습니다.');
+    }
+
+    function disconnect() {
+        if (stompClient !== null) {
+            stompClient.disconnect();
+        }
+        console.log("연결 해제됨");
+        alert('연결이 해제되었습니다.');
+    }
+
+    function createChatRoom() {
+        const userId = document.getElementById('user-id').value;
+        const salonId = document.getElementById('salon-id').value;
+
+        fetch(`/api/chat/room?userId=${userId}&salonId=${salonId}`, {
+            method: 'POST'
+        })
+            .then(response => response.json())
+            .then(data => {
+                currentChatRoomId = parseInt(data.id, 10); // 문자열을 숫자로 변환
+                document.getElementById('chat-room-id').value = currentChatRoomId;
+                console.log('채팅방 생성/조회 성공:', data);
+                alert('채팅방 생성/조회 성공! 채팅방 ID: ' + currentChatRoomId);
+
+                // 기존 메시지 로드
+                loadMessages();
+            })
+            .catch(error => {
+                console.error('채팅방 생성/조회 오류:', error);
+                alert('채팅방 생성/조회 중 오류가 발생했습니다.');
+            });
+    }
+
+    function loadMessages() {
+        if (!currentChatRoomId) {
+            alert('채팅방을 먼저 선택해주세요.');
+            return;
+        }
+
+        fetch(`/api/chat/messages/${currentChatRoomId}`)
+            .then(response => response.json())
+            .then(data => {
+                const messageArea = document.getElementById('chat-messages');
+                messageArea.innerHTML = '';
+
+                data.forEach(msg => {
+                    addMessageToUI(msg);
+                });
+            })
+            .catch(error => {
+                console.error('메시지 로드 오류:', error);
+            });
+    }
+
+    let isSubmitting = false;
+
+    function sendMessage() {
+        if (!stompClient || !currentChatRoomId || isSubmitting) {
+            alert('메시지를 보낼 수 없습니다.');
+            return;
+        }
+
+        const messageInput = document.getElementById('message');
+        const messageContent = messageInput.value.trim();
+
+        if (messageContent) {
+            isSubmitting = true;
+
+            const chatMessage = {
+                chatRoomId: parseInt(currentChatRoomId, 10),
+                senderType: currentSenderType,
+                senderId: currentSenderType === 'USER' ? currentUserId : currentSalonId,
+                message: messageContent,
+                photos: []
+            };
+
+            console.log('전송할 메시지:', chatMessage);
+
+            stompClient.send("/app/chat.sendMessage", {}, JSON.stringify(chatMessage));
+            messageInput.value = '';
+
+            // 0.5초 후에 다시 전송 가능하도록 설정
+            setTimeout(() => {
+                isSubmitting = false;
+            }, 500);
+        }
+    }
+
+    function onMessageReceived(payload) {
+        const message = JSON.parse(payload.body);
+        addMessageToUI(message);
+    }
+
+    function addMessageToUI(message) {
+        const messageArea = document.getElementById('chat-messages');
+        const messageElement = document.createElement('div');
+
+        const isCurrentUser = (message.senderType === currentSenderType);
+        messageElement.classList.add(isCurrentUser ? 'user-message' : 'salon-message');
+
+        const time = new Date(message.sentAt).toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'});
+
+        messageElement.innerHTML = `
+            <div><strong>${message.senderType}</strong> (${time})</div>
+            <div>${message.message}</div>
+        `;
+
+        // 사진이 있는 경우 처리
+        if (message.photos && message.photos.length > 0) {
+            const photosDiv = document.createElement('div');
+            photosDiv.style.marginTop = '5px';
+
+            message.photos.forEach(photo => {
+                const img = document.createElement('img');
+                img.src = photo.photoUrl;
+                img.style.maxWidth = '200px';
+                img.style.maxHeight = '200px';
+                img.style.marginRight = '5px';
+                photosDiv.appendChild(img);
+            });
+
+            messageElement.appendChild(photosDiv);
+        }
+
+        messageArea.appendChild(messageElement);
+        messageArea.scrollTop = messageArea.scrollHeight;
+    }
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 작업 내용 및 기능 요약
- Admin 페이지에서 등록한 Salon과 일반 페이지에서 등록한 User 간의 1:1 채팅 구현
- User의 언어 정보를 가져와 ko(한국어)가 아닐 경우 번역 진행(Salon의 언어는 언제나 ko로 가정)
- 번역 캐시 관리는 현재는 보류하고 추후 따로 구현하도록 하겠습니다

## 스크린샷
(테스트를 위해 임시로 만든 html입니다 추후 삭제하겠습니다)
![image](https://github.com/user-attachments/assets/6620b328-5cf2-4942-847f-c12cc2f334c7)

## 관련 이슈
resolves #14 