### PR TITLE
[FEAT]채팅에서 쿠키 활용 구현

### DIFF
--- a/IMJM-client/src/pages/Chat/ChatList.tsx
+++ b/IMJM-client/src/pages/Chat/ChatList.tsx
@@ -23,9 +23,10 @@ const ChatList: React.FC = () => {
     useEffect(() => {
         const fetchChatRooms = async () => {
             try {
-                // 현재 로그인한 사용자 ID (실제로는 인증 서비스에서 가져와야 함)
-                const userId = 'user2'; // 테스트용 사용자 ID
-                const rooms = await ChatService.getUserChatRooms(userId);
+                // 쿠키 확인 로깅 추가
+                console.log('Current Cookies:', document.cookie);
+                
+                const rooms = await ChatService.getUserChatRooms(); // 파라미터 제거
                 setChatRooms(rooms);
                 setLoading(false);
             } catch (error) {

--- a/IMJM-client/src/pages/Chat/ChatRoom.tsx
+++ b/IMJM-client/src/pages/Chat/ChatRoom.tsx
@@ -279,7 +279,7 @@ const ChatRoom: React.FC = () => {
                 chatRoomId: chatRoom.id,
                 senderType: 'USER',
                 senderId: userId,
-                message: newMessage || selectedFiles.length > 0 ? '사진을 보냈습니다.' : '',
+                message: newMessage.trim() ? newMessage : (selectedFiles.length > 0 ? '사진을 보냈습니다.' : ''),
                 isRead: false,
                 sentAt: new Date().toISOString(),
                 translatedMessage: null,

--- a/IMJM-client/src/services/chat/ChatService.ts
+++ b/IMJM-client/src/services/chat/ChatService.ts
@@ -39,9 +39,11 @@ class ChatService {
     private baseUrl = '/api/chat';
 
     // 사용자 기준 채팅방 목록 조회
-    async getUserChatRooms(userId: string): Promise<ChatRoom[]> {
+    async getUserChatRooms(): Promise<ChatRoom[]> {
         try {
-            const response = await axios.get(`${this.baseUrl}/rooms/user/${userId}`);
+            const response = await axios.get(`/api/chat/rooms/user`, {
+                withCredentials: true  // 쿠키 포함
+            });
             return response.data;
         } catch (error) {
             console.error('Failed to fetch user chat rooms:', error);

--- a/IMJM-server/src/main/java/com/IMJM/chat/controller/ChatController.java
+++ b/IMJM-server/src/main/java/com/IMJM/chat/controller/ChatController.java
@@ -3,10 +3,12 @@ package com.IMJM.chat.controller;
 import com.IMJM.chat.dto.ChatMessageDto;
 import com.IMJM.chat.dto.ChatRoomDto;
 import com.IMJM.chat.service.ChatService;
+import com.IMJM.user.dto.CustomOAuth2UserDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
@@ -27,8 +29,9 @@ public class ChatController {
     }
 
     // 채팅방 목록 조회 (사용자)
-    @GetMapping("/rooms/user/{userId}")
-    public ResponseEntity<List<ChatRoomDto>> getUserChatRooms(@PathVariable String userId) {
+    @GetMapping("/rooms/user")
+    public ResponseEntity<List<ChatRoomDto>> getUserChatRooms(@AuthenticationPrincipal CustomOAuth2UserDto userDetails) {
+        String userId = userDetails.getId();
         return ResponseEntity.ok(chatService.getUserChatRooms(userId));
     }
 


### PR DESCRIPTION
## 작업 내용 및 기능 요약
- 채팅방 목록 조회에서 사용자 ID 하드코딩했던 값 삭제
- 쿠키에서 사용자 ID값 받아와서 채팅방 조회에 사용할 수 있도록 구현

## 스크린샷
![image](https://github.com/user-attachments/assets/8002234f-ee05-4581-bddf-c60c44a60fcd)

## 관련 이슈
resolve #44 