### PR TITLE
[FEAT] 관리자 페이지 대시보드 1차

### DIFF
--- a/IMJM-admin/package-lock.json
+++ b/IMJM-admin/package-lock.json
@@ -21,7 +21,8 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-redux": "^9.2.0",
-        "react-router-dom": "^7.4.0"
+        "react-router-dom": "^7.4.0",
+        "recharts": "^2.15.3"
       },
       "devDependencies": {
         "@eslint/js": "^9.21.0",
@@ -1542,6 +1543,69 @@
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
@@ -1937,6 +2001,127 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.13",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
@@ -1959,6 +2144,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -2299,12 +2490,27 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
+      "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -2631,6 +2837,15 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -2807,6 +3022,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -3225,6 +3446,21 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -3240,6 +3476,44 @@
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.3",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.3.tgz",
+      "integrity": "sha512-EdOPzTwcFSuqtvkDoaM5ws/Km1+WTAO2eizL7rqiG0V2UVhTnz0m7J2i0CjVPUCdEkZImaWvXLbZDS2H5t6GFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/redux": {
       "version": "5.0.1",
@@ -3425,6 +3699,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/turbo-stream": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
@@ -3492,6 +3772,28 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/IMJM-admin/package.json
+++ b/IMJM-admin/package.json
@@ -23,7 +23,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^9.2.0",
-    "react-router-dom": "^7.4.0"
+    "react-router-dom": "^7.4.0",
+    "recharts": "^2.15.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",

--- a/IMJM-admin/src/pages/dashboard/Dashboard.tsx
+++ b/IMJM-admin/src/pages/dashboard/Dashboard.tsx
@@ -1,8 +1,178 @@
+import React, { useEffect, useState } from "react";
+import axios from "axios";
+
+import {
+    Grid, Card, CardContent, Typography, Box, Divider, List,
+    ListItem, ListItemText
+} from "@mui/material";
+import {
+    BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip,
+    Legend
+} from "recharts";
+
+const chats = [
+    { user: "홍길동", message: "예약 시간 변경 가능한가요?", time: "1분 전" },
+];
+
+const reviews = [
+    { user: "신동역", date: "2025-03-21", answered: true },
+    { user: "임성철", date: "2025-03-22", answered: false },
+];
+
+const chartData = [
+    { day: "월", 주간: 45, 월간: 25 },
+    { day: "화", 주간: 30, 월간: 20 },
+    { day: "수", 주간: 35, 월간: 30 },
+    { day: "목", 주간: 45, 월간: 35 },
+    { day: "금", 주간: 15, 월간: 10 },
+    { day: "토", 주간: 40, 월간: 28 },
+    { day: "일", 주간: 38, 월간: 27 },
+];
+
 function Dashboard() {
+    const [todayReservations, setTodayReservations] = useState([]);
+
+    useEffect(() => {
+        axios.get("/api/admin/dashboard/reservation")
+            .then(res => setTodayReservations(res.data))
+            .catch(err => console.error("예약 정보 불러오기 실패", err));
+    }, []);
+
     return (
-        <div className="page-container">
-            <h1>대시보드</h1>
-        </div>
+        <Box width={950} height={780} p={3} mx="auto">
+            <Typography variant="h4" gutterBottom>대시보드</Typography>
+
+            <Grid container spacing={5}>
+                {/* 오늘 예약 현황 */}
+                <Grid item>
+                    <Card
+                        sx={{
+                            width: 450,
+                            height: 310,
+                            boxShadow: "none",
+                            border: "2px solid #FF9080",
+                            borderRadius: "10px"
+                        }}
+                    >
+                        <CardContent>
+                            <Typography variant="h6">오늘 예약 현황 ({todayReservations.length})</Typography>
+                            <Divider sx={{ my: 1 }} />
+                            <Box component="table" width="100%" sx={{ fontSize: 14 }}>
+                                <thead>
+                                    <tr>
+                                        <th align="center">이름</th>
+                                        <th align="center">메뉴</th>
+                                        <th align="center">예약 시간</th>
+                                        <th align="center">디자이너</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {todayReservations.map((r, index) => (
+                                        <tr key={index}>
+                                            <td align="center">{r.userName}</td>
+                                            <td align="center">{r.serviceName}</td>
+                                            <td align="center">{r.reservationTime}</td>
+                                            <td align="center">{r.stylistName}</td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </Box>
+                        </CardContent>
+                    </Card>
+                </Grid>
+
+                {/* 예약 통계 */}
+                <Grid item>
+                <Card
+                        sx={{
+                            width: 450,
+                            height: 310,
+                            boxShadow: "none",
+                            border: "2px solid #FF9080",
+                            borderRadius: "10px"
+                        }}
+                    >
+                        <CardContent>
+                            <Typography variant="h6">예약 통계</Typography>
+                            <Divider sx={{ my: 1 }} />
+                            <Box width="100%" height={200}>
+                                <BarChart width={400} height={200} data={chartData}>
+                                    <CartesianGrid strokeDasharray="3 3" />
+                                    <XAxis dataKey="day" />
+                                    <YAxis />
+                                    <Tooltip />
+                                    <Legend />
+                                    <Bar dataKey="주간" fill="#3f51b5" />
+                                    <Bar dataKey="월간" fill="#ce93d8" />
+                                </BarChart>
+                            </Box>
+                        </CardContent>
+                    </Card>
+                </Grid>
+
+                {/* 채팅 */}
+                <Grid item>
+                <Card
+                        sx={{
+                            width: 450,
+                            height: 310,
+                            boxShadow: "none",
+                            border: "2px solid #FF9080",
+                            borderRadius: "10px"
+                        }}
+                    >
+                        <CardContent>
+                            <Typography variant="h6">채팅 ({chats.length})</Typography>
+                            <Divider sx={{ my: 1 }} />
+                            <List>
+                                {chats.map((chat, index) => (
+                                    <ListItem key={index} divider>
+                                        <ListItemText primary={chat.user} secondary={chat.message} />
+                                        <Typography variant="body2">{chat.time}</Typography>
+                                    </ListItem>
+                                ))}
+                            </List>
+                        </CardContent>
+                    </Card>
+                </Grid>
+
+                {/* 리뷰 관리 */}
+                <Grid item>
+                <Card
+                        sx={{
+                            width: 450,
+                            height: 310,
+                            boxShadow: "none",
+                            border: "2px solid #FF9080",
+                            borderRadius: "10px"
+                        }}
+                    >
+                        <CardContent>
+                            <Typography variant="h6">리뷰 관리 ({reviews.length})</Typography>
+                            <Divider sx={{ my: 1 }} />
+                            <Box component="table" width="100%" sx={{ fontSize: 14 }}>
+                                <thead>
+                                    <tr>
+                                        <th align="left">작성자(고객명)</th>
+                                        <th align="left">작성 날짜</th>
+                                        <th align="left">답변여부</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {reviews.map((r, index) => (
+                                        <tr key={index}>
+                                            <td>{r.user}</td>
+                                            <td>{r.date}</td>
+                                            <td>{r.answered ? "✔️" : "—"}</td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </Box>
+                        </CardContent>
+                    </Card>
+                </Grid>
+            </Grid>
+        </Box>
     );
 }
 

--- a/IMJM-client/src/pages/MyPage/MyPage.tsx
+++ b/IMJM-client/src/pages/MyPage/MyPage.tsx
@@ -5,7 +5,6 @@ import { useNavigate } from "react-router-dom";
 const menuItems = [
   { label: "My Profile", path: "/profile" },
   { label: "Point", path: "/point", right: "10,000 P" },
-  { label: "My Coupons", path: "/coupons" },
   { label: "Appointment history", path: "/appointments" },
   { label: "My Review", path: "/reviews" },
   { label: "My Acahive", path: "/acahive" },

--- a/IMJM-server/src/main/java/com/IMJM/admin/controller/AdminDashboardController.java
+++ b/IMJM-server/src/main/java/com/IMJM/admin/controller/AdminDashboardController.java
@@ -1,0 +1,30 @@
+package com.IMJM.admin.controller;
+
+import com.IMJM.admin.dto.AdminReservationDto;
+import com.IMJM.admin.dto.CustomSalonDetails;
+import com.IMJM.admin.service.AdminReservationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/dashboard")
+public class AdminDashboardController {
+
+    private final AdminReservationService adminReservationService;
+
+    @GetMapping("/reservation")
+    public ResponseEntity<?> dashboardReservation(@AuthenticationPrincipal CustomSalonDetails salonDetails){
+        String today = "today";
+        List<AdminReservationDto> todayReservationDtos = adminReservationService.getAdminReservation(salonDetails.getSalonId(), today);
+
+        return ResponseEntity.ok().body(todayReservationDtos);
+    }
+}

--- a/IMJM-server/src/main/java/com/IMJM/admin/dto/AdminReservationDto.java
+++ b/IMJM-server/src/main/java/com/IMJM/admin/dto/AdminReservationDto.java
@@ -45,4 +45,5 @@ public class AdminReservationDto {
         @JsonFormat(pattern = "HH:mm:ss")
         private String reservationTime;
     }
+
 }

--- a/IMJM-server/src/main/java/com/IMJM/admin/service/AdminReservationService.java
+++ b/IMJM-server/src/main/java/com/IMJM/admin/service/AdminReservationService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -26,8 +27,19 @@ public class AdminReservationService {
 
         List<Payment> payments = paymentRepository.findByReservation_Stylist_Salon_id(salonId);
 
+        if (date.equals("today")) {
+            LocalDate today = LocalDate.now();
+
+            return payments.stream()
+                    .filter(payment -> payment.getReservation().getReservationDate().isEqual(today))
+                    .sorted(Comparator.comparing(p -> p.getReservation().getReservationTime()))
+                    .map(AdminReservationDto::new)
+                    .collect(Collectors.toList());
+        }
+
         return payments.stream()
                 .filter(payment -> payment.getReservation().getReservationDate().isEqual(LocalDate.parse(date)))
+                .sorted(Comparator.comparing(p -> p.getReservation().getReservationTime()))
                 .map(AdminReservationDto::new)
                 .collect(Collectors.toList());
     }
@@ -42,4 +54,5 @@ public class AdminReservationService {
                 adminReservationUpdateDto.getReservationTime()
         );
     }
+
 }

--- a/IMJM-server/src/main/java/com/IMJM/config/SecurityConfig.java
+++ b/IMJM-server/src/main/java/com/IMJM/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import com.IMJM.jwt.UserJWTFilter;
 import com.IMJM.jwt.UserSuccessHandler;
 import com.IMJM.user.service.CustomOAuth2UserService;
 import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -26,6 +27,12 @@ import java.util.List;
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+
+    @Value("${app.client.domain}")
+    private String clientDomain;
+
+    @Value("${app.admin.domain}")
+    private String adminDomain;
 
     private final AuthenticationConfiguration authenticationConfiguration;
     private final UserSuccessHandler userSuccessHandler;
@@ -66,7 +73,7 @@ public class SecurityConfig {
 
                                 CorsConfiguration configuration = new CorsConfiguration();
 
-                                configuration.setAllowedOrigins(List.of("http://localhost:3000", "http://localhost:3030"));
+                                configuration.setAllowedOrigins(List.of(clientDomain, adminDomain));
                                 configuration.setAllowedMethods(List.of("*"));
                                 configuration.setAllowedHeaders(List.of("*"));
                                 configuration.setExposedHeaders(List.of("Set-Cookie", "Authorization"));

--- a/IMJM-server/src/main/java/com/IMJM/config/WebMvcConfig.java
+++ b/IMJM-server/src/main/java/com/IMJM/config/WebMvcConfig.java
@@ -1,5 +1,6 @@
 package com.IMJM.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
@@ -8,11 +9,18 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebMvcConfig implements WebMvcConfigurer {
 
+    @Value("${app.client.domain}")
+    private String clientDomain;
+
+    @Value("${app.admin.domain}")
+    private String adminDomain;
+
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .exposedHeaders("Set-Cookie")
-                .allowedOrigins("http://localhost:3000", "http://localhost:3030")
+                .allowedOrigins(clientDomain, adminDomain)
                 .allowedMethods("*")
                 .allowCredentials(true);
     }

--- a/IMJM-server/src/main/java/com/IMJM/jwt/UserSuccessHandler.java
+++ b/IMJM-server/src/main/java/com/IMJM/jwt/UserSuccessHandler.java
@@ -5,6 +5,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -16,6 +17,9 @@ import java.util.Iterator;
 
 @Component
 public class UserSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    @Value("${app.client.domain}")
+    private String clientDomain;
 
     private final JWTUtil jwtUtil;
 
@@ -41,9 +45,9 @@ public class UserSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
         response.addCookie(createCookie("Authorization", token));
 
         if (!customUserDetails.isTermsAgreed()) {
-            response.sendRedirect("http://localhost:3000/user/language");
+            response.sendRedirect(clientDomain + "/user/language");
         } else {
-            response.sendRedirect("http://localhost:3000/");
+            response.sendRedirect(clientDomain);
         }
     }
 

--- a/IMJM-server/src/main/java/com/IMJM/reservation/repository/ReservationRepository.java
+++ b/IMJM-server/src/main/java/com/IMJM/reservation/repository/ReservationRepository.java
@@ -36,4 +36,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
                 ORDER BY r.reservationDate DESC, r.reservationTime DESC
             """)
     List<Reservation> findPastReservationsBySalonIdOrderByDateTimeDesc(String salonId);
+
+    List<Reservation> findByStylist_Salon_id(String salonId);
 }

--- a/IMJM-server/src/main/resources/application.properties
+++ b/IMJM-server/src/main/resources/application.properties
@@ -73,3 +73,7 @@ server.servlet.encoding.force=true
 # upload max size setting (10 MB)
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
+
+# domain
+app.client.domain=http://localhost:3000
+app.admin.domain=http://localhost:3030


### PR DESCRIPTION
## 작업 내용 및 기능 요약
관리자 페이지 대시보드 1차
예약 현황까지만 구현
 - 그래프, 채팅, 리뷰관리는 다른 사람 완료 시 FE에 api 호출하여 정보 가져올 예정

## 스크린샷
![image](https://github.com/user-attachments/assets/b5293891-661d-41c0-b510-83b8ba818005)

## 관련 이슈
close: #65 