### PR TITLE
[FEAT] 채팅방 삭제 기능 구현 및 클라이언트 채팅 발신 오류 수정

### DIFF
--- a/IMJM-admin/src/pages/chat/AdminChatRoom.tsx
+++ b/IMJM-admin/src/pages/chat/AdminChatRoom.tsx
@@ -18,6 +18,10 @@ import ImageIcon from '@mui/icons-material/Image';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
 import AdminChatService, { ChatMessage, ChatPhoto } from '../../service/chat/AdminChatService';
 import AdminWebSocketService from '../../service/chat/AdminWebSocketService';
 import AdminFileUploadService from '../../service/chat/AdminFileUploadService';
@@ -356,6 +360,8 @@ const AdminChatRoom: React.FC = () => {
 
     const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
     const isMenuOpen = Boolean(menuAnchorEl);
+    const [confirmOpen, setConfirmOpen] = useState(false);
+    const [deletedOpen, setDeletedOpen] = useState(false);
 
     const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
         setMenuAnchorEl(event.currentTarget);
@@ -373,6 +379,20 @@ const AdminChatRoom: React.FC = () => {
         }
     };
 
+    const handleDeleteMenuClick = () => {
+        setConfirmOpen(true);
+    };
+
+    const handleConfirmDelete = async () => {
+        try {
+            await axios.delete(`/api/chat/room/${roomId}`);
+            setConfirmOpen(false);
+            setDeletedOpen(true);
+        } catch (error) {
+            console.error('채팅방 삭제 실패:', error);
+            alert('삭제에 실패했습니다.');
+        }
+    };
 
     if (loading && messages.length === 0) {
         return (
@@ -397,7 +417,7 @@ const AdminChatRoom: React.FC = () => {
                     <MoreVertIcon />
                 </IconButton>
                 <Menu anchorEl={menuAnchorEl} open={isMenuOpen} onClose={handleMenuClose}>
-                    <MenuItem onClick={handleDeleteRoom}>채팅방 삭제</MenuItem>
+                    <MenuItem onClick={handleDeleteMenuClick}>채팅방 삭제</MenuItem>
                 </Menu>
             </Box>
 
@@ -549,6 +569,40 @@ const AdminChatRoom: React.FC = () => {
                     className={styles.messageInput}
                 />
             </Box>
+
+            <Dialog open={confirmOpen} onClose={() => setConfirmOpen(false)}>
+                <DialogTitle>채팅방 삭제</DialogTitle>
+                <DialogContent>
+                    <Typography>
+                        채팅방을 삭제하면 모든 메시지와 사진이 함께 삭제됩니다. 계속하시겠습니까?
+                    </Typography>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={() => setConfirmOpen(false)}>취소</Button>
+                    <Button onClick={handleConfirmDelete} color="error">삭제</Button>
+                </DialogActions>
+            </Dialog>
+
+            <Dialog open={deletedOpen} onClose={() => {
+                setDeletedOpen(false);
+                navigate('/chat');
+            }}>
+                <DialogTitle>삭제 완료</DialogTitle>
+                <DialogContent>
+                    <Typography>채팅방이 성공적으로 삭제되었습니다.</Typography>
+                </DialogContent>
+                <DialogActions>
+                    <Button
+                        onClick={() => {
+                            setDeletedOpen(false);
+                            navigate('/chat');
+                        }}
+                        autoFocus
+                    >
+                        확인
+                    </Button>
+                </DialogActions>
+            </Dialog>
         </Paper>
     );
 };

--- a/IMJM-admin/src/pages/chat/AdminChatRoom.tsx
+++ b/IMJM-admin/src/pages/chat/AdminChatRoom.tsx
@@ -15,6 +15,9 @@ import {
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import SendIcon from '@mui/icons-material/Send';
 import ImageIcon from '@mui/icons-material/Image';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
 import AdminChatService, { ChatMessage, ChatPhoto } from '../../service/chat/AdminChatService';
 import AdminWebSocketService from '../../service/chat/AdminWebSocketService';
 import AdminFileUploadService from '../../service/chat/AdminFileUploadService';
@@ -351,6 +354,26 @@ const AdminChatRoom: React.FC = () => {
         }
     };
 
+    const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
+    const isMenuOpen = Boolean(menuAnchorEl);
+
+    const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
+        setMenuAnchorEl(event.currentTarget);
+    };
+    const handleMenuClose = () => {
+        setMenuAnchorEl(null);
+    };
+    const handleDeleteRoom = async () => {
+        try {
+            await axios.delete(`/api/chat/room/${roomId}`);
+            navigate('/chat');
+        } catch (error) {
+            console.error('채팅방 삭제 실패:', error);
+            alert('채팅방 삭제에 실패했습니다.');
+        }
+    };
+
+
     if (loading && messages.length === 0) {
         return (
             <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '400px' }}>
@@ -363,13 +386,19 @@ const AdminChatRoom: React.FC = () => {
     return (
         <Paper elevation={3} className={styles.container}>
             {/* 헤더 */}
-            <Box className={styles.header}>
+            <Box className={styles.header} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                 <Box sx={{ display: 'flex', alignItems: 'center' }}>
                     <IconButton onClick={handleBackClick} size="small">
                         <ArrowBackIcon />
                     </IconButton>
                     <Typography variant="h6" sx={{ ml: 2, fontWeight: 'bold' }}>{userName}</Typography>
                 </Box>
+                <IconButton onClick={handleMenuOpen}>
+                    <MoreVertIcon />
+                </IconButton>
+                <Menu anchorEl={menuAnchorEl} open={isMenuOpen} onClose={handleMenuClose}>
+                    <MenuItem onClick={handleDeleteRoom}>채팅방 삭제</MenuItem>
+                </Menu>
             </Box>
 
             <Divider />

--- a/IMJM-admin/src/pages/chat/AdminChatRoom.tsx
+++ b/IMJM-admin/src/pages/chat/AdminChatRoom.tsx
@@ -54,13 +54,10 @@ const AdminChatRoom: React.FC = () => {
     const messagesEndRef = useRef<HTMLDivElement>(null);
     const navigate = useNavigate();
 
-    // 번역 요청 및 토글 함수
     const handleTranslateRequest = async (message: ChatMessage) => {
         const messageId = message.id;
 
-        // 이미 번역이 로드되었으면 토글 수행
         if (translations[messageId] && !translations[messageId].isLoading) {
-            // 이미 번역이 표시되어 있으면 제거
             if (!translations[messageId].error && translations[messageId].text) {
                 setTranslations(prev => {
                     const newTranslations = { ...prev };
@@ -70,9 +67,7 @@ const AdminChatRoom: React.FC = () => {
                 return;
             }
 
-            // 에러가 있으면 다시 시도
             if (translations[messageId].error) {
-                // 로딩 상태로 설정
                 setTranslations(prev => ({
                     ...prev,
                     [messageId]: { isLoading: true, text: null, error: null }
@@ -87,7 +82,6 @@ const AdminChatRoom: React.FC = () => {
             return;
         }
 
-        // 로딩 상태로 설정
         setTranslations(prev => ({
             ...prev,
             [messageId]: { isLoading: true, text: null, error: null }
@@ -104,7 +98,6 @@ const AdminChatRoom: React.FC = () => {
         }
     };
 
-    // 실제 번역 요청을 수행하는 함수
     const requestTranslation = async (message: ChatMessage) => {
         const messageId = message.id;
         const sourceLang = message.senderType === 'USER' ? userLanguage : salonLanguage;
@@ -135,15 +128,12 @@ const AdminChatRoom: React.FC = () => {
             try {
                 if (!roomId) return;
 
-                // 현재 로그인된 미용실 정보 가져오기
                 const salonResponse = await axios.get('/api/admin/salons/my');
                 const currentSalonId = salonResponse.data.id;
                 setSalonId(currentSalonId);
 
-                // WebSocket 초기화
                 AdminWebSocketService.initialize(currentSalonId);
 
-                // 채팅방 정보 가져오기 - 새 API 사용
                 try {
                     const roomResponse = await axios.get(`/api/chat/admin/room/${roomId}`);
                     if (roomResponse.data && roomResponse.data.userName) {
@@ -151,51 +141,41 @@ const AdminChatRoom: React.FC = () => {
                     }
                 } catch (roomError) {
                     console.error('채팅방 정보를 불러오는데 실패했습니다:', roomError);
-                    // 오류 발생 시 대체 방법으로 진행 (아래 메시지 로딩 시 처리)
                 }
 
-                // 채팅 메시지 로드
                 const chatMessages = await AdminChatService.getChatMessages(Number(roomId));
                 setMessages(chatMessages);
 
-                // 사용자 이름이 아직 설정되지 않은 경우 메시지에서 추출
                 if (!userName && chatMessages.length > 0) {
-                    // 사용자가 보낸 메시지 찾기
                     const userMessage = chatMessages.find(msg => msg.senderType === 'USER');
 
                     if (userMessage) {
                         try {
-                            // 사용자 정보 요청 - 이 API는 사용자 정보를 제공하는 엔드포인트가 있다고 가정
                             const userResponse = await axios.get(`/api/user/info/${userMessage.senderId}`);
                             if (userResponse.data) {
-                                // 닉네임 또는 이름 사용
                                 setUserName(userResponse.data.nickname ||
                                     (userResponse.data.firstName + ' ' + userResponse.data.lastName));
                             } else {
-                                // 대체: 사용자 ID 사용
                                 setUserName(userMessage.senderId);
                             }
                         } catch (userError) {
                             console.error('사용자 정보를 불러오는데 실패했습니다:', userError);
-                            // 대체: 사용자 ID 사용
                             setUserName(userMessage.senderId);
                         }
                     }
                 }
 
-                // 메시지 읽음 처리
                 await AdminChatService.markMessagesAsRead(Number(roomId));
 
                 setLoading(false);
             } catch (error) {
-                console.error('채팅방 정보를 불러오는데 실패했습니다:', error);
+                navigate('/chat');
                 setLoading(false);
             }
         };
 
         fetchSalonAndChatRoom();
 
-        // 메시지 수신 리스너 설정
         const handleNewMessage = (messageData: ChatMessage) => {
             if (messageData.chatRoomId === Number(roomId)) {
                 setMessages(prev => {
@@ -220,7 +200,6 @@ const AdminChatRoom: React.FC = () => {
                     }
                 });
 
-                // 메시지 읽음 처리 - 본인이 보낸 메시지가 아닌 경우만
                 if (messageData.senderType !== 'SALON') {
                     AdminChatService.markMessagesAsRead(Number(roomId))
                         .catch(err => console.error("메시지 읽음 처리 실패:", err));
@@ -240,7 +219,6 @@ const AdminChatRoom: React.FC = () => {
 
     }, [roomId, userId, userName]);
 
-    // 메시지 스크롤 처리
     useEffect(() => {
         scrollToBottom();
     }, [messages]);
@@ -258,7 +236,6 @@ const AdminChatRoom: React.FC = () => {
         fileInputRef.current?.click();
     };
 
-    // 파일 변경 핸들러
     const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const files = e.target.files;
         if (!files || files.length === 0) return;
@@ -281,32 +258,27 @@ const AdminChatRoom: React.FC = () => {
         }
     };
 
-    // 선택한 파일 제거
     const removeSelectedFile = (index: number) => {
         URL.revokeObjectURL(previewUrls[index]);
         setSelectedFiles(prev => prev.filter((_, i) => i !== index));
         setPreviewUrls(prev => prev.filter((_, i) => i !== index));
     };
 
-    // 메시지 전송
     const handleSendMessage = async () => {
         if (sending || (!newMessage.trim() && selectedFiles.length === 0) || !salonId || !roomId) return;
 
         setSending(true);
 
         try {
-            // 사진이 있는 경우 먼저 업로드
             let photoAttachments: ChatPhoto[] = [];
 
             if (selectedFiles.length > 0) {
                 try {
-                    // 여러 이미지를 개별적으로 업로드
                     const uploadResults = await AdminFileUploadService.uploadMultipleImages(
                         selectedFiles,
                         Number(roomId)
                     );
 
-                    // 업로드 결과를 ChatPhoto 형식으로 변환
                     photoAttachments = uploadResults.map((result, index) => ({
                         photoId: Date.now() + index,
                         photoUrl: result.fileUrl
@@ -319,7 +291,6 @@ const AdminChatRoom: React.FC = () => {
                 }
             }
 
-            // 임시 메시지 객체 생성 (UI에 즉시 표시용)
             const tempMessage: ChatMessage = {
                 id: Date.now(), // 임시 ID
                 chatRoomId: Number(roomId),
@@ -333,10 +304,8 @@ const AdminChatRoom: React.FC = () => {
                 photos: photoAttachments
             };
 
-            // 메시지를 즉시 UI에 추가
             setMessages(prev => [...prev, tempMessage]);
 
-            // WebSocket을 통해 메시지 전송
             AdminWebSocketService.sendMessageWithPhotos(
                 Number(roomId),
                 newMessage.trim() ? newMessage : (selectedFiles.length > 0 ? '사진을 보냈습니다.' : ''),
@@ -344,7 +313,6 @@ const AdminChatRoom: React.FC = () => {
                 photoAttachments
             );
 
-            // 입력 필드 및 선택된 파일 초기화
             setNewMessage('');
             setSelectedFiles([]);
             previewUrls.forEach(url => URL.revokeObjectURL(url));

--- a/IMJM-client/src/pages/Chat/ChatRoom.tsx
+++ b/IMJM-client/src/pages/Chat/ChatRoom.tsx
@@ -36,7 +36,6 @@ interface ChatRoomInfo {
     salonLanguage: string;
 }
 
-// 번역 상태를 관리하기 위한 인터페이스
 interface TranslationState {
     isLoading: boolean;
     text: string | null;
@@ -59,23 +58,13 @@ const ChatRoom: React.FC = () => {
     const navigate = useNavigate();
     const [userId, setUserId] = useState<string>('');
 
-    // WebSocket 연결 및 메시지 수신 설정
     useEffect(() => {
         if (!roomId || !userId) return;
 
-        console.log("메시지 리스너 설정 - 룸ID:", roomId, "유저ID:", userId);
-
-        // 메시지 수신 리스너 등록
         const handleNewMessage = (messageData: ChatMessageDto) => {
-            console.log("새 메시지 수신:", messageData);
 
-            // 현재 채팅방과 관련된 메시지인지 확인
             if (messageData.chatRoomId === Number(roomId)) {
-                console.log("현재 채팅방 메시지 감지됨");
-
-                // 상태 업데이트 함수를 사용하여 메시지 배열 업데이트
                 setMessages(prevMessages => {
-                    // 중복 메시지 확인 로직
                     const isDuplicate = prevMessages.some(msg =>
                         msg.id === messageData.id ||
                         (msg.message === messageData.message &&
@@ -84,7 +73,6 @@ const ChatRoom: React.FC = () => {
                     );
 
                     if (isDuplicate) {
-                        console.log("중복 메시지 감지, 기존 메시지 업데이트");
                         return prevMessages.map(msg =>
                             (msg.id === messageData.id ||
                                 (msg.message === messageData.message &&
@@ -93,50 +81,37 @@ const ChatRoom: React.FC = () => {
                                 ? messageData : msg
                         );
                     } else {
-                        console.log("새 메시지 추가:", messageData);
-                        // 스프레드 연산자를 사용하여 새 배열 생성
                         const newMessages = [...prevMessages, messageData];
-                        console.log("업데이트된 메시지 배열:", newMessages);
                         return newMessages;
                     }
                 });
 
-                // 메시지 읽음 처리 - 본인이 보낸 메시지가 아닌 경우만
                 if (messageData.senderType !== 'USER') {
                     ChatService.markMessagesAsRead(Number(roomId), 'USER')
                         .catch(err => console.error("메시지 읽음 처리 실패:", err));
                 }
             } else {
-                console.log("다른 채팅방 메시지, 무시됨");
             }
         };
 
-        // 리스너 등록
         WebSocketService.addListener('message', handleNewMessage);
-        console.log("메시지 리스너 등록 완료");
 
-        // 컴포넌트 언마운트 시 리스너 제거
         return () => {
-            console.log("메시지 리스너 제거");
             WebSocketService.removeListener('message', handleNewMessage);
         };
     }, [userId, roomId]);
 
-    // 채팅방 정보와 메시지 로드
     useEffect(() => {
         const fetchUserAndChatRoom = async () => {
             try {
                 if (!roomId) return;
 
-                // 현재 로그인된 사용자 정보 가져오기
                 const userResponse = await axios.get('/api/chat/user/current');
                 const currentUserId = userResponse.data.id;
                 setUserId(currentUserId);
 
-                // WebSocket 초기화
                 WebSocketService.initialize(currentUserId);
 
-                // 채팅방 정보 가져오기
                 const roomResponse = await axios.get(`/api/chat/room/${roomId}`);
                 setChatRoom({
                     id: Number(roomId),
@@ -146,16 +121,14 @@ const ChatRoom: React.FC = () => {
                     salonLanguage: roomResponse.data.salonLanguage
                 });
 
-                // 채팅 메시지 로드
                 const chatMessages = await ChatService.getChatMessages(Number(roomId));
                 setMessages(chatMessages);
 
-                // 메시지 읽음 처리
                 await ChatService.markMessagesAsRead(Number(roomId), 'USER');
 
                 setLoading(false);
             } catch (err) {
-                console.error('채팅방 정보를 불러오는데 실패했습니다:', err);
+                navigate('/chat');
                 setLoading(false);
             }
         };
@@ -163,7 +136,6 @@ const ChatRoom: React.FC = () => {
         fetchUserAndChatRoom();
     }, [roomId]);
 
-    // 메시지 스크롤 처리
     useEffect(() => {
         scrollToBottom();
     }, [messages]);
@@ -176,12 +148,10 @@ const ChatRoom: React.FC = () => {
         navigate('/chat');
     };
 
-    // 파일 선택 핸들러
     const handleFileSelect = () => {
         fileInputRef.current?.click();
     };
 
-    // 파일 변경 핸들러
     const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const files = e.target.files;
         if (!files || files.length === 0) return;
@@ -199,26 +169,21 @@ const ChatRoom: React.FC = () => {
         setSelectedFiles(prev => [...prev, ...newFiles]);
         setPreviewUrls(prev => [...prev, ...newPreviewUrls]);
 
-        // 파일 선택 후 input 값 초기화 (같은 파일 다시 선택 가능하도록)
         if (fileInputRef.current) {
             fileInputRef.current.value = '';
         }
     };
 
-    // 선택한 파일 제거 핸들러
     const removeSelectedFile = (index: number) => {
         URL.revokeObjectURL(previewUrls[index]); // 메모리 누수 방지
         setSelectedFiles(prev => prev.filter((_, i) => i !== index));
         setPreviewUrls(prev => prev.filter((_, i) => i !== index));
     };
 
-    // 번역 요청 및 토글 함수
     const handleTranslateRequest = async (message: ChatMessageDto) => {
         const messageId = message.id;
 
-        // 이미 번역이 로드되었으면 토글 수행
         if (translations[messageId] && !translations[messageId].isLoading) {
-            // 이미 번역이 표시되어 있으면 제거
             if (!translations[messageId].error && translations[messageId].text) {
                 setTranslations(prev => {
                     const newTranslations = { ...prev };
@@ -228,9 +193,7 @@ const ChatRoom: React.FC = () => {
                 return;
             }
 
-            // 에러가 있으면 다시 시도
             if (translations[messageId].error) {
-                // 로딩 상태로 설정
                 setTranslations(prev => ({
                     ...prev,
                     [messageId]: { isLoading: true, text: null, error: null }
@@ -245,7 +208,6 @@ const ChatRoom: React.FC = () => {
             return;
         }
 
-        // 로딩 상태로 설정
         setTranslations(prev => ({
             ...prev,
             [messageId]: { isLoading: true, text: null, error: null }
@@ -262,7 +224,6 @@ const ChatRoom: React.FC = () => {
         }
     };
 
-    // 실제 번역 요청을 수행하는 함수
     const requestTranslation = async (message: ChatMessageDto) => {
         if (!chatRoom) return;
 
@@ -296,15 +257,12 @@ const ChatRoom: React.FC = () => {
         setLoading(true); // 메시지 전송 중 로딩 상태 설정
 
         try {
-            // 사진이 있는 경우 먼저 업로드
             let photoAttachments: ChatPhoto[] = [];
 
             if (selectedFiles.length > 0) {
                 try {
-                    // 여러 이미지를 개별적으로 업로드
                     const uploadResults = await FileUploadService.uploadMultipleImages(selectedFiles, chatRoom.id);
 
-                    // 업로드 결과를 ChatPhoto 형식으로 변환
                     photoAttachments = uploadResults.map((result, index) => ({
                         photoId: Date.now() + index, // 고유 ID 생성
                         photoUrl: result.fileUrl
@@ -317,7 +275,6 @@ const ChatRoom: React.FC = () => {
                 }
             }
 
-            // 임시 메시지 객체 생성 (UI에 즉시 표시용)
             const tempMessage: ChatMessageDto = {
                 id: Date.now(), // 임시 ID
                 chatRoomId: chatRoom.id,
@@ -331,17 +288,13 @@ const ChatRoom: React.FC = () => {
                 photos: photoAttachments
             };
 
-            // 메시지를 즉시 UI에 추가
             setMessages(prev => [...prev, tempMessage]);
 
-            // 입력 필드 및 선택된 파일 초기화
             setNewMessage('');
             setSelectedFiles([]);
             previewUrls.forEach(url => URL.revokeObjectURL(url));
             setPreviewUrls([]);
 
-            // WebSocket만 통해 메시지 전송 - 여기서 중복 발송하지 않도록 주의
-            // ChatService.sendMessage()와 같은 REST API 호출이 있다면 제거
             const response = await WebSocketService.sendMessageWithPhotos(
                 chatRoom.id,
                 tempMessage.message,
@@ -351,8 +304,6 @@ const ChatRoom: React.FC = () => {
 
             console.log("메시지 전송 응답:", response);
 
-            // 서버 응답을 받았을 때만 임시 메시지를 업데이트 (선택 사항)
-            // 서버에서 제대로 된 응답을 받지 못하더라도 UI에는 이미 표시됨
             if (response && response.id && response.id !== tempMessage.id) {
                 setMessages(prev =>
                     prev.map(msg =>

--- a/IMJM-client/src/pages/Chat/ChatRoom.tsx
+++ b/IMJM-client/src/pages/Chat/ChatRoom.tsx
@@ -18,6 +18,10 @@ import MoreVertIcon from '@mui/icons-material/MoreVert';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import Box from '@mui/material/Box';
+import Dialog from '@mui/material/Dialog';
+import DialogTitle from '@mui/material/DialogTitle';
+import DialogContent from '@mui/material/DialogContent';
+import DialogActions from '@mui/material/DialogActions';
 import styles from './ChatRoom.module.css';
 import ChatService, { ChatMessageDto, ChatPhoto } from '../../services/chat/ChatService';
 import WebSocketService from '../../services/chat/WebSocketService';
@@ -367,6 +371,8 @@ const ChatRoom: React.FC = () => {
 
     const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
     const openMenu = Boolean(anchorEl);
+    const [confirmOpen, setConfirmOpen] = useState(false);
+    const [deletedOpen, setDeletedOpen] = useState(false);
 
     const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
         setAnchorEl(event.currentTarget);
@@ -381,6 +387,21 @@ const ChatRoom: React.FC = () => {
         } catch (error) {
             console.error('채팅방 삭제 실패:', error);
             alert('채팅방 삭제에 실패했습니다.');
+        }
+    };
+
+    const handleDeleteMenuClick = () => {
+        setConfirmOpen(true);
+    };
+
+    const handleConfirmDelete = async () => {
+        try {
+            await axios.delete(`/api/chat/room/${roomId}`);
+            setConfirmOpen(false);
+            setDeletedOpen(true);
+        } catch (error) {
+            console.error('채팅방 삭제 실패:', error);
+            alert('삭제에 실패했습니다.');
         }
     };
 
@@ -410,7 +431,7 @@ const ChatRoom: React.FC = () => {
                     <MoreVertIcon />
                 </IconButton>
                 <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleMenuClose}>
-                    <MenuItem onClick={handleDeleteRoom}>채팅방 삭제</MenuItem>
+                    <MenuItem onClick={handleDeleteMenuClick}>채팅방 삭제</MenuItem>
                 </Menu>
             </div>
 
@@ -553,6 +574,40 @@ const ChatRoom: React.FC = () => {
                     }}
                 />
             </div>
+
+            <Dialog open={confirmOpen} onClose={() => setConfirmOpen(false)}>
+                <DialogTitle>채팅방 삭제</DialogTitle>
+                <DialogContent>
+                    <Typography>
+                        채팅방을 삭제하면 모든 메시지와 사진이 함께 삭제됩니다. 계속하시겠습니까?
+                    </Typography>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={() => setConfirmOpen(false)}>취소</Button>
+                    <Button onClick={handleConfirmDelete} color="error">삭제</Button>
+                </DialogActions>
+            </Dialog>
+
+            <Dialog open={deletedOpen} onClose={() => {
+                setDeletedOpen(false);
+                navigate('/chat');
+            }}>
+                <DialogTitle>삭제 완료</DialogTitle>
+                <DialogContent>
+                    <Typography>채팅방이 성공적으로 삭제되었습니다.</Typography>
+                </DialogContent>
+                <DialogActions>
+                    <Button
+                        onClick={() => {
+                            setDeletedOpen(false);
+                            navigate('/chat');
+                        }}
+                        autoFocus
+                    >
+                        확인
+                    </Button>
+                </DialogActions>
+            </Dialog>
         </div>
     );
 };

--- a/IMJM-client/src/pages/Chat/ChatRoom.tsx
+++ b/IMJM-client/src/pages/Chat/ChatRoom.tsx
@@ -14,6 +14,10 @@ import {
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import SendIcon from '@mui/icons-material/Send';
 import ImageIcon from '@mui/icons-material/Image';
+import MoreVertIcon from '@mui/icons-material/MoreVert';
+import Menu from '@mui/material/Menu';
+import MenuItem from '@mui/material/MenuItem';
+import Box from '@mui/material/Box';
 import styles from './ChatRoom.module.css';
 import ChatService, { ChatMessageDto, ChatPhoto } from '../../services/chat/ChatService';
 import WebSocketService from '../../services/chat/WebSocketService';
@@ -361,6 +365,25 @@ const ChatRoom: React.FC = () => {
         }
     };
 
+    const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+    const openMenu = Boolean(anchorEl);
+
+    const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
+        setAnchorEl(event.currentTarget);
+    };
+    const handleMenuClose = () => {
+        setAnchorEl(null);
+    };
+    const handleDeleteRoom = async () => {
+        try {
+            await axios.delete(`/api/chat/room/${roomId}`);
+            navigate('/chat'); // 삭제 후 채팅방 목록으로 이동
+        } catch (error) {
+            console.error('채팅방 삭제 실패:', error);
+            alert('채팅방 삭제에 실패했습니다.');
+        }
+    };
+
     if (loading && messages.length === 0) {
         return (
             <div className={styles.loading}>
@@ -372,11 +395,23 @@ const ChatRoom: React.FC = () => {
 
     return (
         <div className={styles.container}>
-            <div className={styles.header}>
-                <IconButton onClick={handleBackClick} size="small">
-                    <ArrowBackIcon />
+            <div className={styles.header} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                <Box sx={{ display: 'flex', alignItems: 'center' }}>
+                    <IconButton onClick={handleBackClick} size="small">
+                        <ArrowBackIcon />
+                    </IconButton>
+                    <Typography variant="h6" sx={{ ml: 2, fontWeight: 'bold' }}>
+                        {chatRoom?.salonName || userName || '채팅방'}
+                    </Typography>
+                </Box>
+
+                {/* 오른쪽 케밥 메뉴 */}
+                <IconButton onClick={handleMenuOpen}>
+                    <MoreVertIcon />
                 </IconButton>
-                <Typography variant="h6">{chatRoom?.salonName || '채팅방'}</Typography>
+                <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleMenuClose}>
+                    <MenuItem onClick={handleDeleteRoom}>채팅방 삭제</MenuItem>
+                </Menu>
             </div>
 
             <div className={styles.messagesContainer}>

--- a/IMJM-client/src/services/chat/WebSocketService.ts
+++ b/IMJM-client/src/services/chat/WebSocketService.ts
@@ -79,7 +79,6 @@ class WebSocketService {
     }
 
     // 메시지 전송 (사진 포함)
-    // WebSocketService.ts의 sendMessageWithPhotos 메서드 수정
     async sendMessageWithPhotos(chatRoomId: number, content: string, senderType: string, photos: ChatPhoto[] = []) {
         console.log("메시지 전송 시작:", { chatRoomId, content, senderType, photos });
 
@@ -92,7 +91,7 @@ class WebSocketService {
             chatRoomId,
             message: content || (photos.length > 0 ? '사진을 보냈습니다.' : ''),
             senderType,
-            senderId: this.userId || '',
+            senderId: this.userId,
             photos,
         };
 
@@ -101,25 +100,6 @@ class WebSocketService {
             destination: '/app/chat.sendMessage',
             body: JSON.stringify(messagePayload)
         });
-
-        // REST API 전송은 제거하거나 주석 처리
-        /*
-        try {
-            const response = await fetch('/api/chat/message', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json'
-                },
-                body: JSON.stringify(messagePayload)
-            });
-
-            if (response.ok) {
-                return await response.json();
-            }
-        } catch (error) {
-            console.error('REST API 메시지 전송 실패:', error);
-        }
-        */
 
         return messagePayload; // 임시 응답으로 원본 페이로드 반환
     }

--- a/IMJM-server/src/main/java/com/IMJM/chat/controller/ChatController.java
+++ b/IMJM-server/src/main/java/com/IMJM/chat/controller/ChatController.java
@@ -183,4 +183,13 @@ public class ChatController {
 
         return ResponseEntity.ok(roomInfo);
     }
+
+    @DeleteMapping("/room/{chatRoomId}")
+    public ResponseEntity<?> deleteChatRoom(
+            @PathVariable Long chatRoomId,
+            @AuthenticationPrincipal CustomOAuth2UserDto userDetails
+    ) {
+        chatService.deleteChatRoom(chatRoomId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/IMJM-server/src/main/java/com/IMJM/chat/controller/ChatController.java
+++ b/IMJM-server/src/main/java/com/IMJM/chat/controller/ChatController.java
@@ -186,8 +186,7 @@ public class ChatController {
 
     @DeleteMapping("/room/{chatRoomId}")
     public ResponseEntity<?> deleteChatRoom(
-            @PathVariable Long chatRoomId,
-            @AuthenticationPrincipal CustomOAuth2UserDto userDetails
+            @PathVariable Long chatRoomId
     ) {
         chatService.deleteChatRoom(chatRoomId);
         return ResponseEntity.ok().build();

--- a/IMJM-server/src/main/java/com/IMJM/chat/repository/ChatMessageRepository.java
+++ b/IMJM-server/src/main/java/com/IMJM/chat/repository/ChatMessageRepository.java
@@ -26,4 +26,8 @@ public interface ChatMessageRepository  extends JpaRepository<ChatMessage, Long>
 
     @Query("SELECT cm FROM ChatMessage cm LEFT JOIN FETCH cm.chatRoom WHERE cm.chatRoom.id = :chatRoomId ORDER BY cm.sentAt ASC")
     List<ChatMessage> findByChatRoomIdWithChatRoomOrderBySentAtAsc(@Param("chatRoomId") Long chatRoomId);
+
+    List<ChatMessage> findByChatRoomId(Long chatRoomId);
+
+    void deleteByChatRoomId(Long chatRoomId);
 }

--- a/IMJM-server/src/main/java/com/IMJM/chat/repository/ChatPhotosRepository.java
+++ b/IMJM-server/src/main/java/com/IMJM/chat/repository/ChatPhotosRepository.java
@@ -10,4 +10,6 @@ public interface ChatPhotosRepository extends JpaRepository<ChatPhotos, Long> {
     List<ChatPhotos> findByChatMessageId(Long chatMessageId);
 
     List<ChatPhotos> findByChatMessageIdIn(List<Long> chatMessageIds);
+
+    void deleteByChatMessageId(Long chatMessageId);
 }

--- a/IMJM-server/src/main/java/com/IMJM/chat/repository/ChatRoomRepository.java
+++ b/IMJM-server/src/main/java/com/IMJM/chat/repository/ChatRoomRepository.java
@@ -2,6 +2,9 @@ package com.IMJM.chat.repository;
 
 import com.IMJM.common.entity.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -9,7 +12,15 @@ import java.util.Optional;
 
 @Repository
 public interface ChatRoomRepository  extends JpaRepository<ChatRoom, Long> {
+
     Optional<ChatRoom> findByUserIdAndSalonId(String userId, String salonId);
+
     List<ChatRoom> findByUserIdOrderByLastMessageTimeDesc(String userId);
+
     List<ChatRoom> findBySalonIdOrderByLastMessageTimeDesc(String salonId);
+
+    // 특정 채팅방 완전 삭제 메서드 추가
+    @Modifying
+    @Query("DELETE FROM ChatRoom cr WHERE cr.id = :chatRoomId")
+    void deleteChatRoomCompletely(@Param("chatRoomId") Long chatRoomId);
 }

--- a/IMJM-server/src/main/java/com/IMJM/chat/repository/ChatRoomRepository.java
+++ b/IMJM-server/src/main/java/com/IMJM/chat/repository/ChatRoomRepository.java
@@ -2,9 +2,6 @@ package com.IMJM.chat.repository;
 
 import com.IMJM.common.entity.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -18,9 +15,4 @@ public interface ChatRoomRepository  extends JpaRepository<ChatRoom, Long> {
     List<ChatRoom> findByUserIdOrderByLastMessageTimeDesc(String userId);
 
     List<ChatRoom> findBySalonIdOrderByLastMessageTimeDesc(String salonId);
-
-    // 특정 채팅방 완전 삭제 메서드 추가
-    @Modifying
-    @Query("DELETE FROM ChatRoom cr WHERE cr.id = :chatRoomId")
-    void deleteChatRoomCompletely(@Param("chatRoomId") Long chatRoomId);
 }

--- a/IMJM-server/src/main/java/com/IMJM/chat/service/ChatService.java
+++ b/IMJM-server/src/main/java/com/IMJM/chat/service/ChatService.java
@@ -466,4 +466,19 @@ public class ChatService {
                 })
                 .collect(Collectors.toList());
     }
+
+    @Transactional
+    public void deleteChatRoom(Long chatRoomId) {
+        // 1. 채팅방의 모든 사진 먼저 삭제
+        List<ChatMessage> messages = chatMessageRepository.findByChatRoomId(chatRoomId);
+        messages.forEach(message -> {
+            chatPhotosRepository.deleteByChatMessageId(message.getId());
+        });
+
+        // 2. 채팅 메시지 삭제
+        chatMessageRepository.deleteByChatRoomId(chatRoomId);
+
+        // 3. 채팅방 삭제
+        chatRoomRepository.deleteById(chatRoomId);
+    }
 }

--- a/IMJM-server/src/main/java/com/IMJM/chat/service/ChatService.java
+++ b/IMJM-server/src/main/java/com/IMJM/chat/service/ChatService.java
@@ -128,25 +128,29 @@ public class ChatService {
         }
 
         // 알림 생성 (수신자가 발신자가 아닌 경우만)
-        if (!recipientId.equals(messageDto.getSenderId())) {
-            // 메시지 내용이 너무 길면 짧게 요약
-            String messagePreview = messageDto.getMessage().length() > 30
-                    ? messageDto.getMessage().substring(0, 30) + "..."
-                    : messageDto.getMessage();
+        if ("SALON".equals(messageDto.getSenderType())) {
+            try {
+                // 메시지 요약 생성
+                String messagePreview = messageDto.getMessage().length() > 30
+                        ? messageDto.getMessage().substring(0, 30) + "..."
+                        : messageDto.getMessage();
 
-            // 사진이 있을 경우 메시지 내용 변경
-            if (messageDto.getPhotos() != null && !messageDto.getPhotos().isEmpty()) {
-                messagePreview = "📷 사진을 보냈습니다.";
+                if (messageDto.getPhotos() != null && !messageDto.getPhotos().isEmpty()) {
+                    messagePreview = "📷 사진을 보냈습니다.";
+                }
+
+                alarmService.createAlarm(
+                        chatRoom.getUser().getId(), // 반드시 User ID
+                        "새 메시지 알림",
+                        senderName + "님이 메시지를 보냈습니다: " + messagePreview,
+                        "CHAT",
+                        chatRoom.getId().intValue()
+                );
+            } catch (Exception e) {
+                System.out.println("⚠️ 알림 생성 중 오류 발생 (무시됨): " + e.getMessage());
             }
-
-            alarmService.createAlarm(
-                    recipientId,
-                    "새 메시지 알림",
-                    senderName + "님이 메시지를 보냈습니다: " + messagePreview,
-                    "CHAT",
-                    chatRoom.getId().intValue()
-            );
         }
+
 
         return responseDto;
     }
@@ -480,5 +484,13 @@ public class ChatService {
 
         // 3. 채팅방 삭제
         chatRoomRepository.deleteById(chatRoomId);
+
+        // 4. 스토리지에서도 폴더 삭제
+        try {
+            String folderPrefix = "chat/" + chatRoomId + "/";
+            storageService.deleteFolder(folderPrefix);
+        } catch (Exception e) {
+            throw new RuntimeException("스토리지에서 채팅 이미지 삭제 중 오류 발생", e);
+        }
     }
 }

--- a/IMJM-server/src/main/java/com/IMJM/config/SecurityConfig.java
+++ b/IMJM-server/src/main/java/com/IMJM/config/SecurityConfig.java
@@ -106,7 +106,7 @@ public class SecurityConfig {
         //경로별 인가 작업
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/**").permitAll()
+                        .requestMatchers("/ws/**").permitAll()
                         .requestMatchers("/api/admin/login", "/api/admin/register").permitAll()
                         .requestMatchers("/admin/check-login").authenticated()
                         .anyRequest().authenticated());


### PR DESCRIPTION
## 작업 내용 및 기능 요약
- 채팅방 삭제 기능 구현하였습니다. 클라이언트와 미용실 한 쪽에서 채팅방을 삭제하면 양쪽 모두에서 삭제됩니다.
- 알람을 구현하면서 클라이언트 측 채팅 메시지 발신에 오류가 생겨 수정하였습니다.

## 스크린샷
![image](https://github.com/user-attachments/assets/73367686-3e88-4b4b-888b-aea462af0c88)
![image](https://github.com/user-attachments/assets/d4bdb324-333b-4c7f-9112-52673cc6ae03)

## 관련 이슈
resolve #113 